### PR TITLE
[BG-130]: 워크스페이스 조회 API 기능 구현 (3h / 2h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -2,10 +2,13 @@ package com.backgu.amaker.workspace.controller
 
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
 import com.backgu.amaker.workspace.service.WorkspaceService
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1")
@@ -18,5 +21,13 @@ class WorkspaceController(
     ) {
         // TODO : 로그인한 사용자의 아이디를 가져와서 넣어줘야함
         workspaceService.createWorkspace(workspaceCreateDto)
+    }
+
+    @GetMapping
+    fun findWorkspaces(
+        @RequestHeader("Authorization") userId: UUID,
+    ) {
+        // TODO : 로그인한 사용자의 아이디를 가져와서 넣어줘야함
+        workspaceService.findWorkspaces(userId)
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceDto.kt
@@ -1,0 +1,7 @@
+package com.backgu.amaker.workspace.dto
+
+class WorkspaceDto(
+    val id: Long,
+    val name: String,
+    val thumbnail: String,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspacesDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspacesDto.kt
@@ -1,0 +1,8 @@
+package com.backgu.amaker.workspace.dto
+
+import java.util.UUID
+
+class WorkspacesDto(
+    val userId: UUID,
+    val workspaces: List<WorkspaceDto>,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceRepository.kt
@@ -2,5 +2,12 @@ package com.backgu.amaker.workspace.repository
 
 import com.backgu.amaker.workspace.domain.Workspace
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
-interface WorkspaceRepository : JpaRepository<Workspace, Long>
+interface WorkspaceRepository : JpaRepository<Workspace, Long> {
+    @Query("select w from Workspace w where w.id in :workspaceIds")
+    fun findByWorkspaceIds(
+        @Param("workspaceIds") workspaceIds: List<Long>,
+    ): List<Workspace>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
@@ -2,5 +2,13 @@ package com.backgu.amaker.workspace.repository
 
 import com.backgu.amaker.workspace.domain.WorkspaceUser
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
 
-interface WorkspaceUserRepository : JpaRepository<WorkspaceUser, Long>
+interface WorkspaceUserRepository : JpaRepository<WorkspaceUser, Long> {
+    @Query("select wu.workspaceId from WorkspaceUser wu where wu.userId = :userId")
+    fun findWorkspaceIdsByUserId(
+        @Param("userId") userId: UUID,
+    ): List<Long>
+}

--- a/api/src/test/kotlin/com/backgu/amaker/auth/service/AuthServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/auth/service/AuthServiceTest.kt
@@ -12,6 +12,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
+@DisplayName("AuthService 테스트")
 class AuthServiceTest {
     private lateinit var authService: AuthService
     private lateinit var googleOAuthClient: GoogleOAuthClient
@@ -42,8 +43,7 @@ class AuthServiceTest {
         googleApiClient = SuccessfulStubGoogleApiClient(email)
         authService = AuthService(googleOAuthClient, googleApiClient, AuthFixture.createUserRequest())
 
-        // when
-        // then
+        // when & then
         assertThatThrownBy { authService.googleLogin("authCode") }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Failed to get access token")
@@ -53,13 +53,11 @@ class AuthServiceTest {
     @DisplayName("구글 oauth 서버에서 토큰 획득 실패 테스트")
     fun failedToUserInfo() {
         // given
-        val email = "abc@gmail.com"
         googleOAuthClient = SuccessfulStubGoogleOAuthClient()
         googleApiClient = FailedFakeGoogleApiClient()
         authService = AuthService(googleOAuthClient, googleApiClient, AuthFixture.createUserRequest())
 
-        // when
-        // then
+        // when & then
         assertThatThrownBy { authService.googleLogin("authCode") }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("Failed to get user information")

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.chat.repository.ChatRoomRepository
+
+class ChatRoomFixture(
+    private val chatRoomRepository: ChatRoomRepository,
+) {
+    fun testChatRoomSetUp() {
+        chatRoomRepository.saveAll(
+            listOf(
+                ChatRoom(workspaceId = 1L, chatRoomType = ChatRoomType.GROUP),
+                ChatRoom(workspaceId = 2L, chatRoomType = ChatRoomType.GROUP),
+            ),
+        )
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
@@ -1,0 +1,40 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.chat.domain.ChatRoomUser
+import com.backgu.amaker.chat.repository.ChatRoomUserRepository
+import java.util.UUID
+
+class ChatRoomUserFixture(
+    private val chatRoomUserRepository: ChatRoomUserRepository,
+) {
+    fun testChatRoomUserSetUp() {
+        chatRoomUserRepository.saveAll(
+            listOf(
+                ChatRoomUser(
+                    chatRoomId = 1L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                ),
+                ChatRoomUser(
+                    chatRoomId = 1L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                ),
+                ChatRoomUser(
+                    chatRoomId = 1L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
+                ),
+                ChatRoomUser(
+                    chatRoomId = 2L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                ),
+                ChatRoomUser(
+                    chatRoomId = 2L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                ),
+                ChatRoomUser(
+                    chatRoomId = 2L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
+                ),
+            ),
+        )
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
@@ -2,11 +2,14 @@ package com.backgu.amaker.fixture
 
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.dto.UserRequest
+import com.backgu.amaker.user.repository.UserRepository
 import java.util.UUID
 
-class UserFixture {
+class UserFixture(
+    private val userRepository: UserRepository,
+) {
     companion object {
-        val defaultUserId = UUID.fromString("00000000-0000-0000-0000-000000000000")
+        val defaultUserId = UUID.fromString("00000000-0000-0000-0000-000000000001")
 
         fun createUserRequest() =
             UserRequest(
@@ -22,5 +25,12 @@ class UserFixture {
                 email = "email",
                 picture = "picture",
             )
+    }
+
+    fun testUserSetUp() {
+        userRepository.save(createUser(defaultUserId))
+        for (i in 2..9) {
+            userRepository.save(createUser(UUID.fromString("00000000-0000-0000-0000-00000000000$i")))
+        }
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
@@ -1,14 +1,35 @@
 package com.backgu.amaker.fixture
 
+import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
+import com.backgu.amaker.workspace.repository.WorkspaceRepository
 import java.util.UUID
 
-class WorkspaceFixture {
+class WorkspaceFixture(
+    private val workspaceRepository: WorkspaceRepository,
+) {
     companion object {
         fun createWorkspaceRequest(userId: UUID) =
             WorkspaceCreateDto(
                 userId = userId,
                 name = "name",
             )
+    }
+
+    fun testWorkspaceSetUp() {
+        workspaceRepository.saveAll(
+            listOf(
+                Workspace(
+                    id = 1L,
+                    name = "워크스페이습",
+                    thumbnail = "image/thumbnail1.png",
+                ),
+                Workspace(
+                    id = 2L,
+                    name = "워크스페이습",
+                    thumbnail = "image/thumbnail2.png",
+                ),
+            ),
+        )
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
@@ -1,0 +1,47 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.workspace.domain.WorkspaceRole
+import com.backgu.amaker.workspace.domain.WorkspaceUser
+import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
+import java.util.UUID
+
+class WorkspaceUserFixture(
+    private val workspaceUserRepository: WorkspaceUserRepository,
+) {
+    fun testWorkspaceUserSetUp() {
+        workspaceUserRepository.saveAll(
+            listOf(
+                WorkspaceUser(
+                    workspaceId = 1L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                    workspaceRole = WorkspaceRole.LEADER,
+                ),
+                WorkspaceUser(
+                    workspaceId = 1L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                    workspaceRole = WorkspaceRole.MEMBER,
+                ),
+                WorkspaceUser(
+                    workspaceId = 1L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
+                    workspaceRole = WorkspaceRole.MEMBER,
+                ),
+                WorkspaceUser(
+                    workspaceId = 2L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
+                    workspaceRole = WorkspaceRole.LEADER,
+                ),
+                WorkspaceUser(
+                    workspaceId = 2L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                    workspaceRole = WorkspaceRole.MEMBER,
+                ),
+                WorkspaceUser(
+                    workspaceId = 2L,
+                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
+                    workspaceRole = WorkspaceRole.MEMBER,
+                ),
+            ),
+        )
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
@@ -6,7 +6,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
 
+@DisplayName("UserService 테스트")
+@Transactional
 @SpringBootTest
 class UserServiceTest {
     @Autowired

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -1,5 +1,3 @@
-
-
 spring:
   application:
     name: a-maker

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
@@ -3,6 +3,8 @@ package com.backgu.amaker.chat.domain
 import com.backgu.amaker.common.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -16,5 +18,7 @@ class ChatRoom(
     val id: Long = 0L,
     @Column(nullable = false)
     val workspaceId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     val chatRoomType: ChatRoomType,
 ) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.workspace.domain
 
 import com.backgu.amaker.common.BaseTimeEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -13,5 +14,8 @@ class Workspace(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
+    @Column(nullable = false)
     var name: String,
+    @Column(nullable = false)
+    var thumbnail: String = "/images/default_thumbnail.png",
 ) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -1,7 +1,10 @@
 package com.backgu.amaker.workspace.domain
 
 import com.backgu.amaker.common.BaseTimeEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -14,7 +17,11 @@ class WorkspaceUser(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
+    @Column(nullable = false)
     val userId: UUID,
+    @Column(nullable = false)
     val workspaceId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
 ) : BaseTimeEntity()


### PR DESCRIPTION
# Why
유저 아이디를 이용하여 유저가 속한 워크스페이스들을 조회
테스트 데이터를 어떤 방식으로 주입 할지에 대한 고민을 꽤 오래동안 해서 시간이 초과함

# How
워크스페이스유저 테이블에서 워크스페이스 아이디를 리스트로 가져온 후
워크스페이스 테이블에서 In 쿼리를 통해 워크스페이스들 정보를 가져오고 있다

FK를 사용하지 않다보니 이런식으로 작성하게 되었다

FK를 사용하지 않을 때 아래중 어떤 방식이 맞는지 모르겠음
`1. QueryDsl를 통한 dto 조회로 해결`
`2. 지금처럼 In 쿼리 사용`

# Result
![image](https://github.com/soma-baekgu/A-Maker-BE/assets/48712043/3e227777-0d9c-4894-ace3-8723cf79e840)

# Prize
FK를 사용하지 않는 것은 이번이 처음이네
조회에서 확실히 불편함이 있다

# Link
BG-130
