### PR TITLE
[BG-193]: WorkspaceUser가 상태 정보를 포함하도록 수정 (0.5H/0.5H)

### DIFF
--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -24,4 +24,7 @@ class WorkspaceUser(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: WorkspaceUserStatus = WorkspaceUserStatus.PENDING,
 ) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUserStatus.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUserStatus.kt
@@ -1,0 +1,9 @@
+package com.backgu.amaker.workspace.domain
+
+enum class WorkspaceUserStatus(
+    var key: String,
+    var value: String,
+) {
+    PENDING("PENDING", "Pending"),
+    ACTIVE("ACTIVE", "Active"),
+}


### PR DESCRIPTION
# Why
유저가 초대에 응하면 초대를 받을 수 있도록 구조를 수정 

# How
유저 초대 기능을 개발하게 되면서 개발하게 됨

# Result

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/4cbcfdcd-1ce1-42fd-af42-cdbc4edfa6fa)


* 아직 필드에 어떤값을 넣는지 까진 정해지지 않은 것 같지만, 
* 대부분 수정될 필드값인 만큼 `varchar`로 설정할 경우 단편화 이슈가 있을 것 같음
* `char`로 설정하는게 좋을 것 같음

# Prize

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/4eed7e34-1613-4aeb-9c86-beb2f2bb4044)

* 기존 테스트에서 수정된 부분 없음

# Reference

BG-193