### PR TITLE
[BG-196]: 도메인 class 추가 (0.5h / 0.5h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
@@ -1,6 +1,6 @@
 package com.backgu.amaker.chat.repository
 
-import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ChatRoomRepository : JpaRepository<ChatRoom, Long>
+interface ChatRoomRepository : JpaRepository<ChatRoomEntity, Long>

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
@@ -1,6 +1,6 @@
 package com.backgu.amaker.chat.repository
 
-import com.backgu.amaker.chat.domain.ChatRoomUser
+import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ChatRoomUserRepository : JpaRepository<ChatRoomUser, Long>
+interface ChatRoomUserRepository : JpaRepository<ChatRoomUserEntity, Long>

--- a/api/src/main/kotlin/com/backgu/amaker/user/dto/UserCreateDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/dto/UserCreateDto.kt
@@ -1,14 +1,14 @@
 package com.backgu.amaker.user.dto
 
-import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.user.jpa.UserEntity
 
 data class UserCreateDto(
     var name: String,
     var email: String,
     var picture: String,
 ) {
-    fun toEntity(): User =
-        User(
+    fun toEntity(): UserEntity =
+        UserEntity(
             name = name,
             email = email,
             picture = picture,

--- a/api/src/main/kotlin/com/backgu/amaker/user/dto/UserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/dto/UserDto.kt
@@ -1,7 +1,7 @@
 package com.backgu.amaker.user.dto
 
-import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.domain.UserRole
+import com.backgu.amaker.user.jpa.UserEntity
 import java.util.UUID
 
 class UserDto(
@@ -12,13 +12,13 @@ class UserDto(
     val userRole: UserRole,
 ) {
     companion object {
-        fun of(user: User): UserDto =
+        fun of(userEntity: UserEntity): UserDto =
             UserDto(
-                id = user.id,
-                name = user.name,
-                email = user.email,
-                picture = user.picture,
-                userRole = user.userRole,
+                id = userEntity.id,
+                name = userEntity.name,
+                email = userEntity.email,
+                picture = userEntity.picture,
+                userRole = userEntity.userRole,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/user/repository/UserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/repository/UserRepository.kt
@@ -1,9 +1,9 @@
 package com.backgu.amaker.user.repository
 
-import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.user.jpa.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface UserRepository : JpaRepository<User, UUID> {
-    fun findByEmail(email: String): User?
+interface UserRepository : JpaRepository<UserEntity, UUID> {
+    fun findByEmail(email: String): UserEntity?
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceRepository.kt
@@ -1,16 +1,16 @@
 package com.backgu.amaker.workspace.repository
 
-import com.backgu.amaker.workspace.domain.Workspace
+import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.UUID
 
-interface WorkspaceRepository : JpaRepository<Workspace, Long> {
+interface WorkspaceRepository : JpaRepository<WorkspaceEntity, Long> {
     @Query("select w from Workspace w where w.id in :workspaceIds")
     fun findByWorkspaceIds(
         @Param("workspaceIds") workspaceIds: List<Long>,
-    ): List<Workspace>
+    ): List<WorkspaceEntity>
 
     @Query(
         "select w " +
@@ -19,5 +19,5 @@ interface WorkspaceRepository : JpaRepository<Workspace, Long> {
             "where wu.userId = :userId " +
             "order by wu.id desc limit 1",
     )
-    fun getDefaultWorkspaceByUserId(userId: UUID): Workspace?
+    fun getDefaultWorkspaceByUserId(userId: UUID): WorkspaceEntity?
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
@@ -1,12 +1,12 @@
 package com.backgu.amaker.workspace.repository
 
-import com.backgu.amaker.workspace.domain.WorkspaceUser
+import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.UUID
 
-interface WorkspaceUserRepository : JpaRepository<WorkspaceUser, Long> {
+interface WorkspaceUserRepository : JpaRepository<WorkspaceUserEntity, Long> {
     @Query("select wu.workspaceId from WorkspaceUser wu where wu.userId = :userId")
     fun findWorkspaceIdsByUserId(
         @Param("userId") userId: UUID,

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
@@ -1,17 +1,17 @@
 package com.backgu.amaker.workspace.service
 
-import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomType
-import com.backgu.amaker.chat.domain.ChatRoomUser
+import com.backgu.amaker.chat.jpa.ChatRoomEntity
+import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import com.backgu.amaker.chat.repository.ChatRoomRepository
 import com.backgu.amaker.chat.repository.ChatRoomUserRepository
 import com.backgu.amaker.user.repository.UserRepository
-import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.domain.WorkspaceRole
-import com.backgu.amaker.workspace.domain.WorkspaceUser
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
 import com.backgu.amaker.workspace.dto.WorkspaceDto
 import com.backgu.amaker.workspace.dto.WorkspacesDto
+import com.backgu.amaker.workspace.jpa.WorkspaceEntity
+import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import com.backgu.amaker.workspace.repository.WorkspaceRepository
 import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -43,37 +43,37 @@ class WorkspaceService(
                 throw EntityNotFoundException("User not found : $userId")
             }
 
-        val workspace =
+        val workspaceEntity =
             workspaceRepository.save(
-                Workspace(
+                WorkspaceEntity(
                     name = request.name,
                 ),
             )
 
         workspaceUserRepository.save(
-            WorkspaceUser(
+            WorkspaceUserEntity(
                 userId = user.id,
-                workspaceId = workspace.id,
+                workspaceId = workspaceEntity.id,
                 workspaceRole = WorkspaceRole.LEADER,
             ),
         )
 
-        val chatRoom =
+        val chatRoomEntity =
             chatRoomRepository.save(
-                ChatRoom(
-                    workspaceId = workspace.id,
+                ChatRoomEntity(
+                    workspaceId = workspaceEntity.id,
                     chatRoomType = ChatRoomType.GROUP,
                 ),
             )
 
         chatRoomUserRepository.save(
-            ChatRoomUser(
+            ChatRoomUserEntity(
                 userId = user.id,
-                chatRoomId = chatRoom.id,
+                chatRoomId = chatRoomEntity.id,
             ),
         )
 
-        return workspace.id
+        return workspaceEntity.id
     }
 
     fun findWorkspaces(userId: UUID): WorkspacesDto {

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
@@ -1,7 +1,7 @@
 package com.backgu.amaker.fixture
 
-import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import com.backgu.amaker.chat.repository.ChatRoomRepository
 
 class ChatRoomFixture(
@@ -10,8 +10,8 @@ class ChatRoomFixture(
     fun testChatRoomSetUp() {
         chatRoomRepository.saveAll(
             listOf(
-                ChatRoom(workspaceId = 1L, chatRoomType = ChatRoomType.GROUP),
-                ChatRoom(workspaceId = 2L, chatRoomType = ChatRoomType.GROUP),
+                ChatRoomEntity(workspaceId = 1L, chatRoomType = ChatRoomType.GROUP),
+                ChatRoomEntity(workspaceId = 2L, chatRoomType = ChatRoomType.GROUP),
             ),
         )
     }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
@@ -1,6 +1,6 @@
 package com.backgu.amaker.fixture
 
-import com.backgu.amaker.chat.domain.ChatRoomUser
+import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import com.backgu.amaker.chat.repository.ChatRoomUserRepository
 import java.util.UUID
 
@@ -10,27 +10,27 @@ class ChatRoomUserFixture(
     fun testChatRoomUserSetUp() {
         chatRoomUserRepository.saveAll(
             listOf(
-                ChatRoomUser(
+                ChatRoomUserEntity(
                     chatRoomId = 1L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 ),
-                ChatRoomUser(
+                ChatRoomUserEntity(
                     chatRoomId = 1L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
                 ),
-                ChatRoomUser(
+                ChatRoomUserEntity(
                     chatRoomId = 1L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
                 ),
-                ChatRoomUser(
+                ChatRoomUserEntity(
                     chatRoomId = 2L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
                 ),
-                ChatRoomUser(
+                ChatRoomUserEntity(
                     chatRoomId = 2L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
                 ),
-                ChatRoomUser(
+                ChatRoomUserEntity(
                     chatRoomId = 2L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
                 ),

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
@@ -1,7 +1,7 @@
 package com.backgu.amaker.fixture
 
-import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.dto.UserCreateDto
+import com.backgu.amaker.user.jpa.UserEntity
 import com.backgu.amaker.user.repository.UserRepository
 import java.util.UUID
 
@@ -19,7 +19,7 @@ class UserFixture(
             )
 
         fun createUser(userId: UUID) =
-            User(
+            UserEntity(
                 id = userId,
                 name = "name",
                 email = "email",

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
@@ -1,7 +1,7 @@
 package com.backgu.amaker.fixture
 
-import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
+import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import com.backgu.amaker.workspace.repository.WorkspaceRepository
 
 class WorkspaceFixture(
@@ -17,12 +17,12 @@ class WorkspaceFixture(
     fun testWorkspaceSetUp() {
         workspaceRepository.saveAll(
             listOf(
-                Workspace(
+                WorkspaceEntity(
                     id = 1L,
                     name = "워크스페이스1",
                     thumbnail = "image/thumbnail1.png",
                 ),
-                Workspace(
+                WorkspaceEntity(
                     id = 2L,
                     name = "워크스페이스2",
                     thumbnail = "image/thumbnail2.png",

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
@@ -1,7 +1,7 @@
 package com.backgu.amaker.fixture
 
 import com.backgu.amaker.workspace.domain.WorkspaceRole
-import com.backgu.amaker.workspace.domain.WorkspaceUser
+import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
 import java.util.UUID
 
@@ -11,32 +11,32 @@ class WorkspaceUserFixture(
     fun testWorkspaceUserSetUp() {
         workspaceUserRepository.saveAll(
             listOf(
-                WorkspaceUser(
+                WorkspaceUserEntity(
                     workspaceId = 1L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
                     workspaceRole = WorkspaceRole.LEADER,
                 ),
-                WorkspaceUser(
+                WorkspaceUserEntity(
                     workspaceId = 1L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
                     workspaceRole = WorkspaceRole.MEMBER,
                 ),
-                WorkspaceUser(
+                WorkspaceUserEntity(
                     workspaceId = 1L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
                     workspaceRole = WorkspaceRole.MEMBER,
                 ),
-                WorkspaceUser(
+                WorkspaceUserEntity(
                     workspaceId = 2L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
                     workspaceRole = WorkspaceRole.LEADER,
                 ),
-                WorkspaceUser(
+                WorkspaceUserEntity(
                     workspaceId = 2L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
                     workspaceRole = WorkspaceRole.MEMBER,
                 ),
-                WorkspaceUser(
+                WorkspaceUserEntity(
                     workspaceId = 2L,
                     userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
                     workspaceRole = WorkspaceRole.MEMBER,

--- a/api/src/test/kotlin/com/backgu/amaker/user/service/UserEntityServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/user/service/UserEntityServiceTest.kt
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 @DisplayName("UserService 테스트")
 @Transactional
 @SpringBootTest
-class UserServiceTest {
+class UserEntityServiceTest {
     @Autowired
     private lateinit var userService: UserService
 

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceEntityUserEntityServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceEntityUserEntityServiceTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.Test
 @DisplayName("WorkspaceService 테스트")
 @Transactional
 @SpringBootTest
-class WorkspaceServiceTest {
+class WorkspaceEntityUserEntityServiceTest {
     @Autowired
     lateinit var workspaceService: WorkspaceService
 

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
@@ -1,24 +1,10 @@
 package com.backgu.amaker.chat.domain
 
-import com.backgu.amaker.common.BaseTimeEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import com.backgu.amaker.common.domain.BaseTime
+import java.util.UUID
 
-@Entity
-@Table(name = "chat_room")
 class ChatRoom(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @Column(nullable = false)
-    val workspaceId: Long,
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    val chatRoomType: ChatRoomType,
-) : BaseTimeEntity()
+    val userId: UUID,
+    val chatRoomId: Long,
+) : BaseTime()

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomUser.kt
@@ -1,22 +1,10 @@
 package com.backgu.amaker.chat.domain
 
-import com.backgu.amaker.common.BaseTimeEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import com.backgu.amaker.common.domain.BaseTime
 import java.util.UUID
 
-@Entity
-@Table(name = "chat_room_user")
 class ChatRoomUser(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @Column(nullable = false)
     val userId: UUID,
-    @Column(nullable = false)
     val chatRoomId: Long,
-) : BaseTimeEntity()
+) : BaseTime()

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomEntity.kt
@@ -1,0 +1,25 @@
+package com.backgu.amaker.chat.jpa
+
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "ChatRoom")
+@Table(name = "chat_room")
+class ChatRoomEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    val workspaceId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val chatRoomType: ChatRoomType,
+) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomUserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomUserEntity.kt
@@ -1,0 +1,22 @@
+package com.backgu.amaker.chat.jpa
+
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity(name = "ChatRoomUser")
+@Table(name = "chat_room_user")
+class ChatRoomUserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    val userId: UUID,
+    @Column(nullable = false)
+    val chatRoomId: Long,
+) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/common/domain/BaseTime.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/common/domain/BaseTime.kt
@@ -2,7 +2,7 @@ package com.backgu.amaker.common.domain
 
 import java.time.LocalDateTime
 
-open class BaseTime(
+abstract class BaseTime(
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/domain/src/main/kotlin/com/backgu/amaker/common/domain/BaseTime.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/common/domain/BaseTime.kt
@@ -1,0 +1,8 @@
+package com.backgu.amaker.common.domain
+
+import java.time.LocalDateTime
+
+open class BaseTime(
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/domain/src/main/kotlin/com/backgu/amaker/common/jpa/BaseTimeEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/common/jpa/BaseTimeEntity.kt
@@ -1,4 +1,4 @@
-package com.backgu.amaker.common
+package com.backgu.amaker.common.jpa
 
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass

--- a/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
@@ -1,26 +1,12 @@
 package com.backgu.amaker.user.domain
 
-import com.backgu.amaker.common.BaseTimeEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import com.backgu.amaker.common.domain.BaseTime
 import java.util.UUID
 
-@Entity
-@Table(name = "users")
 class User(
-    @Id
     var id: UUID = UUID.randomUUID(),
-    @Column(nullable = false)
     var name: String,
-    @Column(nullable = false)
     val email: String,
-    @Column(nullable = false)
     var picture: String,
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     val userRole: UserRole = UserRole.USER,
-) : BaseTimeEntity()
+) : BaseTime()

--- a/domain/src/main/kotlin/com/backgu/amaker/user/jpa/UserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/jpa/UserEntity.kt
@@ -1,0 +1,27 @@
+package com.backgu.amaker.user.jpa
+
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import com.backgu.amaker.user.domain.UserRole
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity(name = "User")
+@Table(name = "users")
+class UserEntity(
+    @Id
+    var id: UUID = UUID.randomUUID(),
+    @Column(nullable = false)
+    var name: String,
+    @Column(nullable = false)
+    val email: String,
+    @Column(nullable = false)
+    var picture: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val userRole: UserRole = UserRole.USER,
+) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
@@ -1,21 +1,9 @@
 package com.backgu.amaker.workspace.domain
 
-import com.backgu.amaker.common.BaseTimeEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import com.backgu.amaker.common.domain.BaseTime
 
-@Entity
-@Table(name = "workspace")
 class Workspace(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @Column(nullable = false)
     var name: String,
-    @Column(nullable = false)
     var thumbnail: String = "/images/default_thumbnail.png",
-) : BaseTimeEntity()
+) : BaseTime()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -1,27 +1,11 @@
 package com.backgu.amaker.workspace.domain
 
-import com.backgu.amaker.common.BaseTimeEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import com.backgu.amaker.common.domain.BaseTime
 import java.util.UUID
 
-@Entity
-@Table(name = "workspace_user")
 class WorkspaceUser(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @Column(nullable = false)
     val userId: UUID,
-    @Column(nullable = false)
     val workspaceId: Long,
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
-) : BaseTimeEntity()
+) : BaseTime()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceEntity.kt
@@ -1,0 +1,21 @@
+package com.backgu.amaker.workspace.jpa
+
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "Workspace")
+@Table(name = "workspace")
+class WorkspaceEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    var name: String,
+    @Column(nullable = false)
+    var thumbnail: String = "/images/default_thumbnail.png",
+) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceUserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceUserEntity.kt
@@ -1,0 +1,28 @@
+package com.backgu.amaker.workspace.jpa
+
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import com.backgu.amaker.workspace.domain.WorkspaceRole
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity(name = "WorkspaceUser")
+@Table(name = "workspace_user")
+class WorkspaceUserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    val userId: UUID,
+    @Column(nullable = false)
+    val workspaceId: Long,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
+) : BaseTimeEntity()


### PR DESCRIPTION
# Why

도메인 레이어를 추가하기 위해 기존의 jpa entity와 대응되는 domain 클래스 정의

# How

기존 0.5H에서 0.5H를 적절히 사용한 것 같다.

# Result

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/308ee497-f209-4c59-98bf-be67f844c6db)
  
![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/f22d3363-30a1-4f7b-a77e-602a8e10a34b)


* 의존관계가 잡혀있지 않기 때문에 매핑 자체는 간단했지만
* `BaseTimeEntity` 부분은 어떻게 매핑해야할지 모르겠어서 
* `BaseTimeEntity`와 대응되는 `BaseTime`을 만듬


# Prize

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/15e38dfe-8870-4125-a824-d8726201c339)

* 테스트는 바뀌지 않음

# Reference
BG-196