### PR TITLE
[BG-200]: 테스트 fixture 리팩토링 (5h / 3h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/auth/dto/oauth/google/GoogleUserInfoDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/auth/dto/oauth/google/GoogleUserInfoDto.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.auth.dto.oauth.google
 
+import com.backgu.amaker.common.service.IdPublisher
 import com.backgu.amaker.user.domain.User
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
@@ -13,8 +14,9 @@ data class GoogleUserInfoDto(
     val givenName: String,
     val picture: String,
 ) {
-    fun toDomain(): User =
+    fun toDomain(idPublisher: IdPublisher): User =
         User(
+            id = idPublisher.publishId(),
             name = name,
             email = email,
             picture = picture,

--- a/api/src/main/kotlin/com/backgu/amaker/auth/service/AuthFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/auth/service/AuthFacadeService.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.auth.service
 
 import com.backgu.amaker.auth.dto.JwtTokenResponse
 import com.backgu.amaker.auth.dto.oauth.google.GoogleUserInfoDto
+import com.backgu.amaker.common.service.IdPublisher
 import com.backgu.amaker.security.jwt.component.JwtComponent
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.service.UserService
@@ -12,11 +13,12 @@ class AuthFacadeService(
     val oauthService: AuthService,
     val jwtComponent: JwtComponent,
     val userService: UserService,
+    val idPublisher: IdPublisher,
 ) {
     fun googleLogin(authorizationCode: String): JwtTokenResponse {
         val userInfo: GoogleUserInfoDto = oauthService.googleLogin(authorizationCode)
         val savedUser: User =
-            userService.saveOrGetUser(userInfo.toDomain())
+            userService.saveOrGetUser(userInfo.toDomain(idPublisher))
         val token: String = jwtComponent.create(savedUser.id, savedUser.userRole.key)
 
         return JwtTokenResponse.of(token, savedUser)

--- a/api/src/main/kotlin/com/backgu/amaker/common/infra/UUIDIdPublisher.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/infra/UUIDIdPublisher.kt
@@ -1,0 +1,10 @@
+package com.backgu.amaker.common.infra
+
+import com.backgu.amaker.common.service.IdPublisher
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class UUIDIdPublisher : IdPublisher {
+    override fun publishId(): String = UUID.randomUUID().toString()
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/service/IdPublisher.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/service/IdPublisher.kt
@@ -1,0 +1,5 @@
+package com.backgu.amaker.common.service
+
+interface IdPublisher {
+    fun publishId(): String
+}

--- a/api/src/main/kotlin/com/backgu/amaker/security/JwtAuthentication.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/JwtAuthentication.kt
@@ -1,8 +1,6 @@
 package com.backgu.amaker.security
 
-import java.util.UUID
-
 class JwtAuthentication(
-    val id: UUID,
+    val id: String,
     val token: String,
 )

--- a/api/src/main/kotlin/com/backgu/amaker/security/filter/JwtAuthenticationTokenFilter.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/filter/JwtAuthenticationTokenFilter.kt
@@ -15,7 +15,6 @@ import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 import java.util.Arrays
 import java.util.Objects
-import java.util.UUID
 import java.util.regex.Pattern
 import java.util.stream.Collectors
 
@@ -36,7 +35,7 @@ class JwtAuthenticationTokenFilter(
                 if (authorizationToken != null) {
                     val claims: JwtComponent.Claims = jwtComponent.verify(authorizationToken)
 
-                    val id: UUID = UUID.fromString(claims.id.replace("\"", ""))
+                    val id: String = claims.id.replace("\"", "")
                     val authorities: List<GrantedAuthority> = obtainAuthorities(claims)
 
                     if (Objects.nonNull(id) && authorities.isNotEmpty()) {

--- a/api/src/main/kotlin/com/backgu/amaker/security/jwt/component/JwtComponent.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/jwt/component/JwtComponent.kt
@@ -7,7 +7,6 @@ import com.auth0.jwt.interfaces.DecodedJWT
 import com.backgu.amaker.security.jwt.config.JwtConfig
 import org.springframework.stereotype.Component
 import java.util.Date
-import java.util.UUID
 
 @Component
 class JwtComponent(
@@ -17,7 +16,7 @@ class JwtComponent(
     private val jwtVerifier = JWT.require(jwtHashAlgorithm).withIssuer(jwtConfig.issuer).build()
 
     fun create(
-        userId: UUID,
+        userId: String,
         role: String,
     ): String = this.create(Claims.of(userId, role))
 
@@ -51,7 +50,7 @@ class JwtComponent(
 
         companion object {
             fun of(
-                id: UUID,
+                id: String,
                 role: String,
             ): Claims {
                 val claims = Claims()

--- a/api/src/main/kotlin/com/backgu/amaker/user/repository/UserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/repository/UserRepository.kt
@@ -2,8 +2,7 @@ package com.backgu.amaker.user.repository
 
 import com.backgu.amaker.user.jpa.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.UUID
 
-interface UserRepository : JpaRepository<UserEntity, UUID> {
+interface UserRepository : JpaRepository<UserEntity, String> {
     fun findByEmail(email: String): UserEntity?
 }

--- a/api/src/main/kotlin/com/backgu/amaker/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/service/UserService.kt
@@ -7,7 +7,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
 
@@ -23,7 +22,7 @@ class UserService(
     }
 
     // TODO exception handling
-    fun getById(id: UUID): User =
+    fun getById(id: String): User =
         userRepository.findByIdOrNull(id)?.toDomain() ?: run {
             logger.error { "User not found : $id" }
             throw IllegalArgumentException("User not found : $id")

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspacesDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspacesDto.kt
@@ -1,8 +1,6 @@
 package com.backgu.amaker.workspace.dto
 
-import java.util.UUID
-
 class WorkspacesDto(
-    val userId: UUID,
+    val userId: String,
     val workspaces: List<WorkspaceDto>,
 )

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspacesDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspacesDto.kt
@@ -1,16 +1,6 @@
 package com.backgu.amaker.workspace.dto
 
-class WorkspaceDto(
-    val id: Long,
-    val name: String,
-    val thumbnail: String,
-) {
-    companion object {
-        fun of(workspace: Workspace): WorkspaceDto =
-            WorkspaceDto(
-                id = workspace.id,
-                name = workspace.name,
-                thumbnail = workspace.thumbnail,
-            )
-    }
-}
+data class WorkspacesDto(
+    val userId: String,
+    val workspaces: List<WorkspaceDto>,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/response/WorkspacesResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/response/WorkspacesResponse.kt
@@ -2,11 +2,10 @@ package com.backgu.amaker.workspace.dto.response
 
 import com.backgu.amaker.workspace.dto.WorkspacesDto
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.UUID
 
 data class WorkspacesResponse(
     @Schema(description = "유저 id", example = "550e8400-e29b-41d4-a716-446655440000")
-    val userId: UUID,
+    val userId: String,
     @Schema(
         description = "유저가 참여하고 있는 워크스페이스들",
         example = "[{\"workspaceId\":1,\"name\":\"백구팀 워크스페이스\",\"thumbnail\":\"https://example.com/thumbnail.jpg\"}]",

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceRepository.kt
@@ -4,7 +4,6 @@ import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.UUID
 
 interface WorkspaceRepository : JpaRepository<WorkspaceEntity, Long> {
     @Query("select w from Workspace w where w.id in :workspaceIds")
@@ -19,5 +18,5 @@ interface WorkspaceRepository : JpaRepository<WorkspaceEntity, Long> {
             "where wu.userId = :userId " +
             "order by wu.id desc limit 1",
     )
-    fun getDefaultWorkspaceByUserId(userId: UUID): WorkspaceEntity?
+    fun getDefaultWorkspaceByUserId(userId: String): WorkspaceEntity?
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
@@ -4,11 +4,10 @@ import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.UUID
 
 interface WorkspaceUserRepository : JpaRepository<WorkspaceUserEntity, Long> {
     @Query("select wu.workspaceId from WorkspaceUser wu where wu.userId = :userId")
     fun findWorkspaceIdsByUserId(
-        @Param("userId") userId: UUID,
+        @Param("userId") userId: String,
     ): List<Long>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -11,7 +11,6 @@ import com.backgu.amaker.workspace.dto.WorkspaceDto
 import com.backgu.amaker.workspace.dto.WorkspacesDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 @Service
 @Transactional(readOnly = true)
@@ -24,7 +23,7 @@ class WorkspaceFacadeService(
 ) {
     @Transactional
     fun createWorkspace(
-        userId: UUID,
+        userId: String,
         workspaceCreateDto: WorkspaceCreateDto,
     ): WorkspaceDto {
         val leader: User = userService.getById(userId)
@@ -37,7 +36,7 @@ class WorkspaceFacadeService(
         return WorkspaceDto.of(workspace)
     }
 
-    fun findWorkspaces(userId: UUID): WorkspacesDto {
+    fun findWorkspaces(userId: String): WorkspacesDto {
         val user: User = userService.getById(userId)
 
         val workspaces: List<Workspace> =
@@ -49,7 +48,7 @@ class WorkspaceFacadeService(
         )
     }
 
-    fun getDefaultWorkspace(userId: UUID): WorkspaceDto {
+    fun getDefaultWorkspace(userId: String): WorkspaceDto {
         val user: User = userService.getById(userId)
         return workspaceService.getDefaultWorkspaceByUserId(user).let { WorkspaceDto.of(it) }
     }

--- a/api/src/test/kotlin/com/backgu/amaker/auth/service/AuthFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/auth/service/AuthFacadeServiceTest.kt
@@ -2,13 +2,10 @@ package com.backgu.amaker.auth.service
 
 import com.backgu.amaker.auth.dto.JwtTokenResponse
 import com.backgu.amaker.fixture.AuthFixture
-import com.backgu.amaker.fixture.UserFixture
 import com.backgu.amaker.security.jwt.component.JwtComponent
-import com.backgu.amaker.user.repository.UserRepository
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -44,15 +41,5 @@ class AuthFacadeServiceTest {
 
         // then
         assertThat(jwtComponent.verify(googleLogin.token)).isNotNull()
-    }
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setUp(
-            @Autowired userRepository: UserRepository,
-        ) {
-            UserFixture(userRepository).testUserSetUp()
-        }
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/common/annotation/IntegrationTestComponent.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/common/annotation/IntegrationTestComponent.kt
@@ -7,4 +7,4 @@ import org.springframework.stereotype.Component
 @Target(AnnotationTarget.CLASS)
 @Primary
 @Component
-annotation class IntegrationTestComponent()
+annotation class IntegrationTestComponent

--- a/api/src/test/kotlin/com/backgu/amaker/common/annotation/IntegrationTestComponent.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/common/annotation/IntegrationTestComponent.kt
@@ -1,0 +1,10 @@
+package com.backgu.amaker.common.annotation
+
+import org.springframework.context.annotation.Primary
+import org.springframework.stereotype.Component
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+@Primary
+@Component
+annotation class IntegrationTestComponent()

--- a/api/src/test/kotlin/com/backgu/amaker/common/infra/StubIdPublisher.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/common/infra/StubIdPublisher.kt
@@ -1,0 +1,17 @@
+package com.backgu.amaker.common.infra
+
+import com.backgu.amaker.common.annotation.IntegrationTestComponent
+import com.backgu.amaker.common.service.IdPublisher
+
+@IntegrationTestComponent
+class StubIdPublisher : IdPublisher {
+    companion object {
+        var counter = 1
+    }
+
+    fun reset() {
+        counter = 1
+    }
+
+    override fun publishId(): String = (counter++).toString()
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
@@ -1,18 +1,31 @@
 package com.backgu.amaker.fixture
 
+import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import com.backgu.amaker.chat.repository.ChatRoomRepository
+import com.backgu.amaker.workspace.domain.Workspace
+import org.springframework.stereotype.Component
 
+@Component
 class ChatRoomFixture(
     private val chatRoomRepository: ChatRoomRepository,
 ) {
-    fun testChatRoomSetUp() {
-        chatRoomRepository.saveAll(
-            listOf(
-                ChatRoomEntity(workspaceId = 1L, chatRoomType = ChatRoomType.GROUP),
-                ChatRoomEntity(workspaceId = 2L, chatRoomType = ChatRoomType.GROUP),
-            ),
-        )
-    }
+    fun createPersistedChatRoom(
+        workspaceId: Long,
+        chatRoomType: ChatRoomType,
+    ): ChatRoom =
+        chatRoomRepository
+            .save(
+                ChatRoomEntity(workspaceId = workspaceId, chatRoomType = chatRoomType),
+            ).toDomain()
+
+    fun testChatRoomSetUp(
+        count: Int,
+        workspace: Workspace,
+        chatRoomType: ChatRoomType? = null,
+    ): List<ChatRoom> =
+        (1..count).map {
+            createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = chatRoomType ?: ChatRoomType.GROUP)
+        }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
@@ -2,39 +2,23 @@ package com.backgu.amaker.fixture
 
 import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import com.backgu.amaker.chat.repository.ChatRoomUserRepository
-import java.util.UUID
+import org.springframework.stereotype.Component
 
+@Component
 class ChatRoomUserFixture(
     private val chatRoomUserRepository: ChatRoomUserRepository,
 ) {
-    fun testChatRoomUserSetUp() {
-        chatRoomUserRepository.saveAll(
-            listOf(
-                ChatRoomUserEntity(
-                    chatRoomId = 1L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                ),
-                ChatRoomUserEntity(
-                    chatRoomId = 1L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                ),
-                ChatRoomUserEntity(
-                    chatRoomId = 1L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
-                ),
-                ChatRoomUserEntity(
-                    chatRoomId = 2L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                ),
-                ChatRoomUserEntity(
-                    chatRoomId = 2L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                ),
-                ChatRoomUserEntity(
-                    chatRoomId = 2L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
-                ),
-            ),
-        )
-    }
+    fun createPersistedChatRoomUser(
+        chatRoomId: Long,
+        userIds: List<String>,
+    ): List<ChatRoomUserEntity> =
+        userIds.map {
+            chatRoomUserRepository
+                .save(
+                    ChatRoomUserEntity(
+                        chatRoomId = chatRoomId,
+                        userId = it,
+                    ),
+                )
+        }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
@@ -15,15 +15,15 @@ class UserFixture(
     companion object {
         fun createUser(
             id: String = UUID.randomUUID().toString(),
-            name: String? = null,
-            email: String? = null,
-            picture: String? = null,
+            name: String = nameBuilder(id),
+            email: String = emailBuilder(id),
+            picture: String = pictureBuilder(id),
         ): User =
             User(
                 id = id,
-                name = name ?: nameBuilder(id),
-                email = email ?: nameBuilder(id),
-                picture = picture ?: nameBuilder(id),
+                name = name,
+                email = email,
+                picture = picture,
             )
 
         private fun nameBuilder(id: Any): String = "name-$id"
@@ -35,9 +35,9 @@ class UserFixture(
 
     fun createPersistedUser(
         id: Any = stubIdPublisher.publishId(),
-        name: String? = null,
-        email: String? = null,
-        picture: String? = null,
+        name: String = nameBuilder(id),
+        email: String = emailBuilder(id),
+        picture: String = pictureBuilder(id),
     ) = userRepository
         .save(
             UserEntity.of(createUser(id.toString(), name, email, picture)),

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
@@ -1,36 +1,49 @@
 package com.backgu.amaker.fixture
 
+import com.backgu.amaker.common.infra.StubIdPublisher
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.jpa.UserEntity
 import com.backgu.amaker.user.repository.UserRepository
+import org.springframework.stereotype.Component
 import java.util.UUID
 
+@Component
 class UserFixture(
     private val userRepository: UserRepository,
+    private val stubIdPublisher: StubIdPublisher,
 ) {
     companion object {
-        val defaultUserId = UUID.fromString("00000000-0000-0000-0000-000000000001")
-
-        fun createUser() =
+        fun createUser(
+            id: String = UUID.randomUUID().toString(),
+            name: String? = null,
+            email: String? = null,
+            picture: String? = null,
+        ): User =
             User(
-                name = "name",
-                email = "email",
-                picture = "picture",
+                id = id,
+                name = name ?: nameBuilder(id),
+                email = email ?: nameBuilder(id),
+                picture = picture ?: nameBuilder(id),
             )
 
-        fun createUserEntity(userId: UUID) =
-            UserEntity(
-                id = userId,
-                name = "name",
-                email = "email",
-                picture = "picture",
-            )
+        private fun nameBuilder(id: Any): String = "name-$id"
+
+        private fun emailBuilder(id: Any): String = "$id@gmail.com"
+
+        private fun pictureBuilder(id: Any): String = "http://server/picture-$id"
     }
 
-    fun testUserSetUp() {
-        userRepository.save(createUserEntity(defaultUserId))
-        for (i in 2..9) {
-            userRepository.save(createUserEntity(UUID.fromString("00000000-0000-0000-0000-00000000000$i")))
-        }
-    }
+    fun createPersistedUser(
+        id: Any = stubIdPublisher.publishId(),
+        name: String? = null,
+        email: String? = null,
+        picture: String? = null,
+    ) = userRepository
+        .save(
+            UserEntity.of(createUser(id.toString(), name, email, picture)),
+        ).toDomain()
+
+    fun createPersistedUsers(count: Long): List<User> = (1..count).map { createPersistedUser(id = it) }
+
+    fun createPersistedUsers(vararg ids: Any): List<User> = ids.map { createPersistedUser(it.toString()) }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
@@ -3,31 +3,38 @@ package com.backgu.amaker.fixture
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
 import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import com.backgu.amaker.workspace.repository.WorkspaceRepository
+import org.springframework.stereotype.Component
 
+@Component
 class WorkspaceFixture(
     private val workspaceRepository: WorkspaceRepository,
 ) {
     companion object {
-        fun createWorkspaceRequest() =
+        fun createWorkspace(
+            id: Long = 0L,
+            name: String?,
+            thumbnail: String?,
+        ) = WorkspaceEntity(
+            id = id,
+            name = name ?: nameBuilder(id),
+            thumbnail = thumbnail ?: thumbnailBuilder(id),
+        )
+
+        fun createWorkspaceRequest(name: String = "default-test") =
             WorkspaceCreateDto(
-                name = "name",
+                name = name,
             )
+
+        private fun nameBuilder(id: Any): String = "name-$id"
+
+        private fun thumbnailBuilder(id: Any): String = "http://server/thumbnail-$id"
     }
 
-    fun testWorkspaceSetUp() {
-        workspaceRepository.saveAll(
-            listOf(
-                WorkspaceEntity(
-                    id = 1L,
-                    name = "워크스페이스1",
-                    thumbnail = "image/thumbnail1.png",
-                ),
-                WorkspaceEntity(
-                    id = 2L,
-                    name = "워크스페이스2",
-                    thumbnail = "image/thumbnail2.png",
-                ),
-            ),
-        )
-    }
+    fun createPersistedWorkspace(
+        name: String? = null,
+        thumbnail: String? = null,
+    ) = workspaceRepository
+        .save(
+            createWorkspace(name = name, thumbnail = thumbnail),
+        ).toDomain()
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
@@ -4,20 +4,22 @@ import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
 import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import com.backgu.amaker.workspace.repository.WorkspaceRepository
 import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicLong
 
 @Component
 class WorkspaceFixture(
     private val workspaceRepository: WorkspaceRepository,
 ) {
     companion object {
+        private var idValue: AtomicLong = AtomicLong(0L)
+
         fun createWorkspace(
-            id: Long = 0L,
-            name: String?,
-            thumbnail: String?,
+            id: Long = idValue.incrementAndGet(),
+            name: String = nameBuilder(id),
+            thumbnail: String = thumbnailBuilder(id),
         ) = WorkspaceEntity(
-            id = id,
-            name = name ?: nameBuilder(id),
-            thumbnail = thumbnail ?: thumbnailBuilder(id),
+            name = name,
+            thumbnail = thumbnail,
         )
 
         fun createWorkspaceRequest(name: String = "default-test") =
@@ -31,8 +33,9 @@ class WorkspaceFixture(
     }
 
     fun createPersistedWorkspace(
-        name: String? = null,
-        thumbnail: String? = null,
+        id: Long = idValue.incrementAndGet(),
+        name: String = nameBuilder(id),
+        thumbnail: String = thumbnailBuilder(id),
     ) = workspaceRepository
         .save(
             createWorkspace(name = name, thumbnail = thumbnail),

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixtureFacade.kt
@@ -1,0 +1,39 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
+import com.backgu.amaker.workspace.domain.WorkspaceUser
+import org.springframework.stereotype.Component
+
+@Component
+class WorkspaceFixtureFacade(
+    val chatRoom: ChatRoomFixture,
+    val chatRoomUser: ChatRoomUserFixture,
+    val workspace: WorkspaceFixture,
+    val workspaceUser: WorkspaceUserFixture,
+    val user: UserFixture,
+) {
+    fun setUp() {
+        val leader: User = user.createPersistedUser(name = "김리더", email = "leader@amaker.com")
+        val workspace: Workspace = workspace.createPersistedWorkspace(name = "테스트 워크스페이스")
+        val members: List<User> = user.createPersistedUsers(10)
+
+        val workspaceUsers: List<WorkspaceUser> =
+            workspaceUser.createPersistedWorkspaceUser(
+                workspaceId = workspace.id,
+                leaderId = leader.id,
+                memberIds = members.map { it.id },
+            )
+
+        val chatRooms: List<ChatRoom> =
+            chatRoom.testChatRoomSetUp(count = 10, workspace = workspace)
+
+        chatRooms.forEach { chatRoom ->
+            chatRoomUser.createPersistedChatRoomUser(
+                chatRoomId = chatRoom.id,
+                userIds = workspaceUsers.map { it.userId },
+            )
+        }
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
@@ -1,47 +1,42 @@
 package com.backgu.amaker.fixture
 
 import com.backgu.amaker.workspace.domain.WorkspaceRole
+import com.backgu.amaker.workspace.domain.WorkspaceUser
 import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
-import java.util.UUID
+import org.springframework.stereotype.Component
 
+@Component
 class WorkspaceUserFixture(
     private val workspaceUserRepository: WorkspaceUserRepository,
 ) {
-    fun testWorkspaceUserSetUp() {
-        workspaceUserRepository.saveAll(
+    fun createPersistedWorkspaceUser(
+        workspaceId: Long,
+        leaderId: String,
+        memberIds: List<String> = emptyList(),
+    ): List<WorkspaceUser> {
+        val workspaceUsers: List<WorkspaceUser> =
             listOf(
-                WorkspaceUserEntity(
-                    workspaceId = 1L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                    workspaceRole = WorkspaceRole.LEADER,
-                ),
-                WorkspaceUserEntity(
-                    workspaceId = 1L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                    workspaceRole = WorkspaceRole.MEMBER,
-                ),
-                WorkspaceUserEntity(
-                    workspaceId = 1L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
-                    workspaceRole = WorkspaceRole.MEMBER,
-                ),
-                WorkspaceUserEntity(
-                    workspaceId = 2L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                    workspaceRole = WorkspaceRole.LEADER,
-                ),
-                WorkspaceUserEntity(
-                    workspaceId = 2L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                    workspaceRole = WorkspaceRole.MEMBER,
-                ),
-                WorkspaceUserEntity(
-                    workspaceId = 2L,
-                    userId = UUID.fromString("00000000-0000-0000-0000-000000000003"),
-                    workspaceRole = WorkspaceRole.MEMBER,
-                ),
-            ),
-        )
+                workspaceUserRepository
+                    .save(
+                        WorkspaceUserEntity(
+                            workspaceId = workspaceId,
+                            userId = leaderId,
+                            workspaceRole = WorkspaceRole.LEADER,
+                        ),
+                    ).toDomain(),
+            ) +
+                memberIds.map {
+                    workspaceUserRepository
+                        .save(
+                            WorkspaceUserEntity(
+                                workspaceId = workspaceId,
+                                userId = it,
+                                workspaceRole = WorkspaceRole.MEMBER,
+                            ),
+                        ).toDomain()
+                }
+
+        return workspaceUsers
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/security/jwt/component/JwtComponentTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/security/jwt/component/JwtComponentTest.kt
@@ -1,7 +1,6 @@
 package com.backgu.amaker.security.jwt.component
 
 import com.auth0.jwt.exceptions.JWTDecodeException
-import com.backgu.amaker.fixture.UserFixture
 import com.backgu.amaker.user.domain.UserRole
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.DisplayName
@@ -22,7 +21,7 @@ class JwtComponentTest {
     @DisplayName("토큰 생성 테스트")
     fun createToken() {
         // given
-        val userId = UserFixture.defaultUserId
+        val userId = "tester"
         val userRole = UserRole.USER.key
 
         // when
@@ -36,7 +35,7 @@ class JwtComponentTest {
     @DisplayName("토큰 검증 테스트")
     fun verifyToken() {
         // given
-        val userId = UserFixture.defaultUserId
+        val userId = "tester"
         val userRole = UserRole.USER.key
         val token = jwtComponent.create(userId, userRole)
 

--- a/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
@@ -3,10 +3,8 @@ package com.backgu.amaker.user.service
 import com.backgu.amaker.fixture.UserFixture
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.domain.UserRole
-import com.backgu.amaker.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -20,14 +18,17 @@ class UserServiceTest {
     @Autowired
     private lateinit var userService: UserService
 
+    @Autowired
+    private lateinit var userFixture: UserFixture
+
     @Test
     @DisplayName("사용자 저장 테스트")
     fun saveUser() {
         // given
-        val request = UserFixture.createUser()
+        val user = UserFixture.createUser()
 
         // when
-        val result = userService.save(request)
+        val result = userService.save(user)
 
         // then
         assertThat(result).isNotNull()
@@ -37,8 +38,8 @@ class UserServiceTest {
     @DisplayName("이메일로 사용자 조회 테스트")
     fun getByEmail() {
         // given
-        val user = User(name = "test", email = "test@gmail.com", picture = "test")
-        val saveUser = userService.save(user)
+        val email = "test@gmail.com"
+        val saveUser = userFixture.createPersistedUser(email = email)
 
         // when
         val result = userService.getByEmail(saveUser.email)
@@ -65,11 +66,10 @@ class UserServiceTest {
     @DisplayName("saveOrGetUser: 존재하는 사용자 조회 테스트")
     fun saveOrGetUserTest() {
         // given
-        val user = User(name = "pre", email = "pre@gmail.com", picture = "pre")
-        val saveUser = userService.save(user)
+        val saveUser = userFixture.createPersistedUser()
 
         // when
-        val result = userService.saveOrGetUser(user)
+        val result = userService.saveOrGetUser(saveUser)
 
         // then
         assertThat(result.id).isEqualTo(saveUser.id)
@@ -84,26 +84,16 @@ class UserServiceTest {
     fun saveOrGetUser_SaveTest() {
         // given
         val user = User(name = "new", email = "new@gmail.com", picture = "new")
-        val savedUser = userService.saveOrGetUser(user)
 
         // when
-        val result = userService.getByEmail(savedUser.email)
+        val savedUser = userService.saveOrGetUser(user)
 
         // then
+        val result = userService.getByEmail(savedUser.email)
         assertThat(result.id).isNotNull()
         assertThat(result.name).isEqualTo(user.name)
         assertThat(result.email).isEqualTo(user.email)
         assertThat(result.picture).isEqualTo(user.picture)
         assertThat(result.userRole).isEqualTo(UserRole.USER)
-    }
-
-    companion object {
-        @JvmStatic
-        @BeforeAll
-        fun setUp(
-            @Autowired userRepository: UserRepository,
-        ) {
-            UserFixture(userRepository).testUserSetUp()
-        }
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.user.service
 
+import com.backgu.amaker.common.service.IdPublisher
 import com.backgu.amaker.fixture.UserFixture
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.domain.UserRole
@@ -17,6 +18,9 @@ import org.springframework.transaction.annotation.Transactional
 class UserServiceTest {
     @Autowired
     private lateinit var userService: UserService
+
+    @Autowired
+    private lateinit var idPublisher: IdPublisher
 
     @Autowired
     private lateinit var userFixture: UserFixture
@@ -83,7 +87,7 @@ class UserServiceTest {
     @DisplayName("saveOrGetUser: 존재하지 않는 사용자 저장 테스트")
     fun saveOrGetUser_SaveTest() {
         // given
-        val user = User(name = "new", email = "new@gmail.com", picture = "new")
+        val user = User(id = idPublisher.publishId(), name = "new", email = "new@gmail.com", picture = "new")
 
         // when
         val savedUser = userService.saveOrGetUser(user)

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -78,7 +78,7 @@ class WorkspaceFacadeServiceTest {
         val result = workspaceFacadeService.getDefaultWorkspace(userId)
 
         // then
-        assertThat(result.id).isEqualTo(workspace2.id)
+        assertThat(result.workspaceId).isEqualTo(workspace2.id)
         assertThat(result.name).isEqualTo("워크스페이스2")
     }
 

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -1,16 +1,8 @@
 package com.backgu.amaker.workspace.service
 
-import com.backgu.amaker.chat.repository.ChatRoomRepository
-import com.backgu.amaker.chat.repository.ChatRoomUserRepository
-import com.backgu.amaker.fixture.ChatRoomFixture
-import com.backgu.amaker.fixture.ChatRoomUserFixture
-import com.backgu.amaker.fixture.UserFixture
-import com.backgu.amaker.fixture.WorkspaceFixture
 import com.backgu.amaker.fixture.WorkspaceFixture.Companion.createWorkspaceRequest
-import com.backgu.amaker.fixture.WorkspaceUserFixture
-import com.backgu.amaker.user.repository.UserRepository
-import com.backgu.amaker.workspace.repository.WorkspaceRepository
-import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
+import com.backgu.amaker.fixture.WorkspaceFixtureFacade
+import com.backgu.amaker.user.domain.User
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
@@ -19,7 +11,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 import kotlin.test.Test
 
 @DisplayName("WorkspaceFacadeService 테스트")
@@ -29,44 +20,65 @@ class WorkspaceFacadeServiceTest {
     @Autowired
     lateinit var workspaceFacadeService: WorkspaceFacadeService
 
+    @Autowired
+    lateinit var fixtures: WorkspaceFixtureFacade
+
     @Test
     @DisplayName("워크 스페이스 생성 테스트")
     fun createWorkspace() {
         // given
-        val request = createWorkspaceRequest()
+        val userId = "tester"
+        fixtures.user.createPersistedUser(userId)
+
+        val request = createWorkspaceRequest("워크스페이스 생성")
 
         // when
-        val result = workspaceFacadeService.createWorkspace(UserFixture.defaultUserId, request)
+        val result = workspaceFacadeService.createWorkspace(userId, request)
 
         // then
-        assertThat(result.id).isEqualTo(3L)
+        assertThat(result.name).isEqualTo("워크스페이스 생성")
     }
 
     @Test
     @DisplayName("유저의 워크스페이스들 조회")
     fun findWorkspaces() {
         // given
-        val userId = UserFixture.defaultUserId
+        val userId = "tester"
+        val user: User = fixtures.user.createPersistedUser(userId)
+        val workspace1 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace1.id, leaderId = userId)
+        val workspace2 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스2")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace2.id, leaderId = userId)
+        val workspace3 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스3")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace3.id, leaderId = userId)
+        val workspace4 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스4")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace4.id, leaderId = userId)
 
         // when
         val result = workspaceFacadeService.findWorkspaces(userId)
 
         // then
         assertThat(result.userId).isEqualTo(userId)
-        assertThat(result.workspaces.size).isEqualTo(2)
+        assertThat(result.workspaces.size).isEqualTo(4)
     }
 
     @Test
     @DisplayName("유저의 기본 워크스페이스 조회")
     fun findDefaultWorkspace() {
         // given
-        val userId = UserFixture.defaultUserId
+        val userId = "tester"
+        fixtures.user.createPersistedUser(userId)
+        val workspace1 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace1.id, leaderId = userId)
+
+        val workspace2 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스2")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace2.id, leaderId = userId)
 
         // when
         val result = workspaceFacadeService.getDefaultWorkspace(userId)
 
         // then
-        assertThat(result.id).isEqualTo(2L)
+        assertThat(result.id).isEqualTo(workspace2.id)
         assertThat(result.name).isEqualTo("워크스페이스2")
     }
 
@@ -74,7 +86,8 @@ class WorkspaceFacadeServiceTest {
     @DisplayName("기본 워크스페이스를 찾을 수 없을 때 실패")
     fun failFindDefaultWorkspace() {
         // given
-        val userId = UUID.fromString("00000000-0000-0000-0000-000000000004")
+        val userId = "tester"
+        fixtures.user.createPersistedUser(userId)
 
         // when & then
         assertThrows<EntityNotFoundException> {
@@ -88,17 +101,9 @@ class WorkspaceFacadeServiceTest {
         @JvmStatic
         @BeforeAll
         fun setUp(
-            @Autowired userRepository: UserRepository,
-            @Autowired workspaceRepository: WorkspaceRepository,
-            @Autowired workspaceUserRepository: WorkspaceUserRepository,
-            @Autowired chatRoomRepository: ChatRoomRepository,
-            @Autowired chatRoomUserRepository: ChatRoomUserRepository,
+            @Autowired workspaceFixtureFacade: WorkspaceFixtureFacade,
         ) {
-            UserFixture(userRepository).testUserSetUp()
-            WorkspaceFixture(workspaceRepository).testWorkspaceSetUp()
-            WorkspaceUserFixture(workspaceUserRepository).testWorkspaceUserSetUp()
-            ChatRoomFixture(chatRoomRepository).testChatRoomSetUp()
-            ChatRoomUserFixture(chatRoomUserRepository).testChatRoomUserSetUp()
+            workspaceFixtureFacade.setUp()
         }
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceServiceTest.kt
@@ -1,0 +1,96 @@
+package com.backgu.amaker.workspace.service
+
+import com.backgu.amaker.fixture.WorkspaceFixtureFacade
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.Test
+
+@DisplayName("WorkspaceService 테스트")
+@Transactional
+@SpringBootTest
+class WorkspaceServiceTest {
+    @Autowired
+    lateinit var fixtures: WorkspaceFixtureFacade
+
+    @Autowired
+    lateinit var workspaceService: WorkspaceService
+
+    @Test
+    @DisplayName("워크스페이스 탐색 테스트")
+    fun getWorkspaceByIdsTest() {
+        // given
+        val userId = "tester"
+        fixtures.user.createPersistedUser(userId)
+        val workspace1 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        val workspace2 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스2")
+        val workspace3 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스3")
+        val workspace4 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스4")
+
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace1.id, leaderId = userId)
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace2.id, leaderId = userId)
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace3.id, leaderId = userId)
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace4.id, leaderId = userId)
+
+        // when
+        val result =
+            workspaceService.getWorkspaceByIds(listOf(workspace1.id, workspace2.id, workspace3.id, workspace4.id))
+
+        // then
+        assertThat(result.size).isEqualTo(4)
+    }
+
+    @Test
+    @DisplayName("디폴트 워크스페이스 조회 테스트")
+    fun getDefaultWorkspaceTest() {
+        // given
+        val userId = "tester"
+        val user: User = fixtures.user.createPersistedUser(userId)
+        val workspace1 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        val workspace2 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스2")
+        val workspace3 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스3")
+        val workspace4 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스4")
+
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace1.id, leaderId = userId)
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace2.id, leaderId = userId)
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace3.id, leaderId = userId)
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace4.id, leaderId = userId)
+
+        // when
+        val result: Workspace = workspaceService.getDefaultWorkspaceByUserId(user)
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result.name).isEqualTo("워크스페이스4")
+    }
+
+    @Test
+    @DisplayName("워크스페이스가 없을 때 디폴트 워크스페이스 조회 테스트")
+    fun getDefaultWorkspaceWhenNoWorkspaceTest() {
+        // given
+        val userId = "tester"
+        val user: User = fixtures.user.createPersistedUser(userId)
+
+        // when & then
+        assertThatThrownBy { workspaceService.getDefaultWorkspaceByUserId(user) }
+            .isInstanceOf(EntityNotFoundException::class.java)
+            .hasMessage("Default workspace not found : tester")
+    }
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setUp(
+            @Autowired workspaceFixtureFacade: WorkspaceFixtureFacade,
+        ) {
+            workspaceFixtureFacade.setUp()
+        }
+    }
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomUser.kt
@@ -1,10 +1,9 @@
 package com.backgu.amaker.chat.domain
 
 import com.backgu.amaker.common.domain.BaseTime
-import java.util.UUID
 
 class ChatRoomUser(
     val id: Long = 0L,
-    val userId: UUID,
+    val userId: String,
     val chatRoomId: Long,
 ) : BaseTime()

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomUserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomUserEntity.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.util.UUID
 
 @Entity(name = "ChatRoomUser")
 @Table(name = "chat_room_user")
@@ -17,7 +16,7 @@ class ChatRoomUserEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
     @Column(nullable = false)
-    val userId: UUID,
+    val userId: String,
     @Column(nullable = false)
     val chatRoomId: Long,
 ) : BaseTimeEntity() {

--- a/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
@@ -4,10 +4,10 @@ import com.backgu.amaker.common.domain.BaseTime
 import com.backgu.amaker.workspace.domain.Workspace
 
 class User(
-    var id: String = "",
-    var name: String,
+    val id: String,
+    val name: String,
     val email: String,
-    var picture: String,
+    val picture: String,
     val userRole: UserRole = UserRole.USER,
 ) : BaseTime() {
     fun createWorkspace(name: String): Workspace {

--- a/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
@@ -5,7 +5,7 @@ import com.backgu.amaker.workspace.domain.Workspace
 import java.util.UUID
 
 class User(
-    var id: UUID = UUID.randomUUID(),
+    var id: String = UUID.randomUUID().toString(),
     var name: String,
     val email: String,
     var picture: String,

--- a/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
@@ -2,10 +2,9 @@ package com.backgu.amaker.user.domain
 
 import com.backgu.amaker.common.domain.BaseTime
 import com.backgu.amaker.workspace.domain.Workspace
-import java.util.UUID
 
 class User(
-    var id: String = UUID.randomUUID().toString(),
+    var id: String = "",
     var name: String,
     val email: String,
     var picture: String,

--- a/domain/src/main/kotlin/com/backgu/amaker/user/jpa/UserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/jpa/UserEntity.kt
@@ -14,7 +14,7 @@ import jakarta.persistence.Table
 @Table(name = "users")
 class UserEntity(
     @Id
-    var id: String = "",
+    var id: String,
     @Column(nullable = false)
     var name: String,
     @Column(nullable = false)

--- a/domain/src/main/kotlin/com/backgu/amaker/user/jpa/UserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/jpa/UserEntity.kt
@@ -9,13 +9,12 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.util.UUID
 
 @Entity(name = "User")
 @Table(name = "users")
 class UserEntity(
     @Id
-    var id: UUID = UUID.randomUUID(),
+    var id: String = "",
     @Column(nullable = false)
     var name: String,
     @Column(nullable = false)

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -1,11 +1,10 @@
 package com.backgu.amaker.workspace.domain
 
 import com.backgu.amaker.common.domain.BaseTime
-import java.util.UUID
 
 class WorkspaceUser(
     val id: Long = 0L,
-    val userId: UUID,
+    val userId: String,
     val workspaceId: Long,
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
 ) : BaseTime()

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceUserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceUserEntity.kt
@@ -11,7 +11,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.util.UUID
 
 @Entity(name = "WorkspaceUser")
 @Table(name = "workspace_user")
@@ -20,7 +19,7 @@ class WorkspaceUserEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
     @Column(nullable = false)
-    val userId: UUID,
+    val userId: String,
     @Column(nullable = false)
     val workspaceId: Long,
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
# Why

간단하게 테스트 픽스처만 리팩토링하려고 했는데,
user의 식별자를 `UUID`에서 `String`으로 수정하면서 작업양이 많아짐

# Result

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/ccea4c3a-f440-43f0-8581-35268645cd82)


# Prize

* 픽스처 자체를 테스트용 스프링 빈으로 등록했다.

```kotlin
@Component
class UserFixture(
    private val userRepository: UserRepository,
    private val stubIdPublisher: StubIdPublisher,
) {
    companion object {
        fun createUser(
            id: String = UUID.randomUUID().toString(),
            name: String? = null,
            email: String? = null,
            picture: String? = null,
        ): User =
            User(
                id = id,
                name = name ?: nameBuilder(id),
                email = email ?: nameBuilder(id),
                picture = picture ?: nameBuilder(id),
            )

        private fun nameBuilder(id: Any): String = "name-$id"

        private fun emailBuilder(id: Any): String = "$id@gmail.com"

        private fun pictureBuilder(id: Any): String = "http://server/picture-$id"
    }

    fun createPersistedUser(
        id: Any = stubIdPublisher.publishId(),
        name: String? = null,
        email: String? = null,
        picture: String? = null,
    ) = userRepository
        .save(
            UserEntity.of(createUser(id.toString(), name, email, picture)),
        ).toDomain()

    fun createPersistedUsers(count: Long): List<User> = (1..count).map { createPersistedUser(id = it) }

    fun createPersistedUsers(vararg ids: Any): List<User> = ids.map { createPersistedUser(it.toString()) }
}
```

* 어그리게이션에 대한 많은 도메인들이 모두 각각의 fixture로 등록되면 코드가 복잡해질 것 같아서 이를 하나로 묶어주었다.
  * 또 여기서 이 어그리케이션에 대해 하나의 데이터셋이 초기화 되어있어야, 전체 데이터가 조회되지는 않는지 테스트 해볼 수 있을 것 같아서 하나의 데이터셋을 만들어줄 수 있는 `setup` 메서드를 따로 만들어 주었다.

```kotlin
@Component
class WorkspaceFixtureFacade(
    val chatRoom: ChatRoomFixture,
    val chatRoomUser: ChatRoomUserFixture,
    val workspace: WorkspaceFixture,
    val workspaceUser: WorkspaceUserFixture,
    val user: UserFixture,
) {
    fun setUp() {
        val leader: User = user.createPersistedUser(name = "김리더", email = "leader@amaker.com")
        val workspace: Workspace = workspace.createPersistedWorkspace(name = "테스트 워크스페이스")
        val members: List<User> = user.createPersistedUsers(10)

        val workspaceUsers: List<WorkspaceUser> =
            workspaceUser.createPersistedWorkspaceUser(
                workspaceId = workspace.id,
                leaderId = leader.id,
                memberIds = members.map { it.id },
            )

        val chatRooms: List<ChatRoom> =
            chatRoom.testChatRoomSetUp(count = 10, workspace = workspace)

        chatRooms.forEach { chatRoom ->
            chatRoomUser.createPersistedChatRoomUser(
                chatRoomId = chatRoom.id,
                userIds = workspaceUsers.map { it.userId },
            )
        }
    }
}
```

* 실제 사용하는 부분에서는 아직 고민이 더 필요할 것 같다.
  * 현재는 수동적으로 각각의 도메인에 대해 수동적으로 세팅해주고 있다.
    * 테스트는 명시적으로 `given`이 보여지는 것이 좋다고 생각하여 이렇게 구성하였다.
    * 하지만 테스트 규모가 커지면 이렇게 처리하기 힘들 것이라 생각하여 추후 방향성은 아직 고민중이다.

```kotlin
@DisplayName("WorkspaceFacadeService 테스트")
@Transactional
@SpringBootTest
class WorkspaceFacadeServiceTest {
    @Autowired
    lateinit var workspaceFacadeService: WorkspaceFacadeService

    @Autowired
    lateinit var fixtures: WorkspaceFixtureFacade

    @Test
    @DisplayName("유저의 워크스페이스들 조회")
    fun findWorkspaces() {
        // given
        val userId = "tester"
        val user: User = fixtures.user.createPersistedUser(userId)
        val workspace1 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace1.id, leaderId = userId)
        val workspace2 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스2")
        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace2.id, leaderId = userId)
        val workspace3 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스3")
        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace3.id, leaderId = userId)
        val workspace4 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스4")
        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace4.id, leaderId = userId)

        // when
        val result = workspaceFacadeService.findWorkspaces(userId)

        // then
        assertThat(result.userId).isEqualTo(userId)
        assertThat(result.workspaces.size).isEqualTo(4)
    }
    //...
}
```

# Link

BG-200