### PR TITLE
[BG-202]: 유저의 워크스페이스에 존재하는 그룹 채팅방 조회 API를 구현 (3h / 2h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatRoomDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatRoomDto.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.chat.dto
+
+import com.backgu.amaker.chat.domain.ChatRoom
+
+data class ChatRoomDto(
+    val chatRoomId: Long,
+    val workspaceId: Long,
+    val chatRoomType: String,
+) {
+    companion object {
+        fun of(chatRoom: ChatRoom): ChatRoomDto =
+            ChatRoomDto(
+                chatRoomId = chatRoom.id,
+                workspaceId = chatRoom.workspaceId,
+                chatRoomType = chatRoom.chatRoomType.name,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatRoomResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatRoomResponse.kt
@@ -1,0 +1,22 @@
+package com.backgu.amaker.chat.dto.response
+
+import com.backgu.amaker.chat.dto.ChatRoomDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ChatRoomResponse(
+    @Schema(description = "채팅방 id", example = "1")
+    val chatRoomId: Long,
+    @Schema(description = "워크스페이스 id", example = "1")
+    val workspaceId: Long,
+    @Schema(description = "채팅방 종류", example = "GROUP")
+    val chatRoomType: String,
+) {
+    companion object {
+        fun of(chatRoomDto: ChatRoomDto): ChatRoomResponse =
+            ChatRoomResponse(
+                chatRoomId = chatRoomDto.chatRoomId,
+                workspaceId = chatRoomDto.workspaceId,
+                chatRoomType = chatRoomDto.chatRoomType,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
@@ -1,6 +1,12 @@
 package com.backgu.amaker.chat.repository
 
+import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ChatRoomRepository : JpaRepository<ChatRoomEntity, Long>
+interface ChatRoomRepository : JpaRepository<ChatRoomEntity, Long> {
+    fun findByWorkspaceIdAndChatRoomType(
+        workspaceId: Long,
+        chatRoomType: ChatRoomType,
+    ): ChatRoomEntity?
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -1,10 +1,16 @@
 package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import com.backgu.amaker.chat.repository.ChatRoomRepository
+import com.backgu.amaker.workspace.domain.Workspace
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 @Transactional(readOnly = true)
@@ -13,4 +19,15 @@ class ChatRoomService(
 ) {
     @Transactional
     fun save(chatRoom: ChatRoom): ChatRoom = chatRoomRepository.save(ChatRoomEntity.of(chatRoom)).toDomain()
+
+    fun getGroupChatRoomByWorkspace(
+        workspace: Workspace,
+        group: ChatRoomType,
+    ): ChatRoom =
+        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspace.id, ChatRoomType.GROUP)?.toDomain()
+            // TODO : 공통 에러처리 추후에 해줘야함
+            ?: run {
+                logger.error { "Group ChatRoom not found in Workspace ${workspace.id}" }
+                throw EntityNotFoundException("Group ChatRoom not found in Workspace ${workspace.id}")
+            }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -20,10 +20,7 @@ class ChatRoomService(
     @Transactional
     fun save(chatRoom: ChatRoom): ChatRoom = chatRoomRepository.save(ChatRoomEntity.of(chatRoom)).toDomain()
 
-    fun getGroupChatRoomByWorkspace(
-        workspace: Workspace,
-        group: ChatRoomType,
-    ): ChatRoom =
+    fun getGroupChatRoomByWorkspace(workspace: Workspace): ChatRoom =
         chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspace.id, ChatRoomType.GROUP)?.toDomain()
             // TODO : 공통 에러처리 추후에 해줘야함
             ?: run {

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -51,7 +51,7 @@ class WorkspaceController(
             WorkspaceResponse.of(workspaceFacadeService.getDefaultWorkspace(token.id)),
         )
 
-    @GetMapping("{workspace-id}/group-chatroom")
+    @GetMapping("{workspace-id}/group-chat-room")
     fun findGroupChatRoom(
         @PathVariable("workspace-id") workspaceId: Long,
         @AuthenticationPrincipal token: JwtAuthentication,

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.workspace.controller
 
+import com.backgu.amaker.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.security.JwtAuthentication
 import com.backgu.amaker.workspace.dto.request.WorkspaceCreateRequest
 import com.backgu.amaker.workspace.dto.response.WorkspaceResponse
@@ -8,6 +9,7 @@ import com.backgu.amaker.workspace.service.WorkspaceFacadeService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -47,5 +49,16 @@ class WorkspaceController(
     ): ResponseEntity<WorkspaceResponse> =
         ResponseEntity.ok().body(
             WorkspaceResponse.of(workspaceFacadeService.getDefaultWorkspace(token.id)),
+        )
+
+    @GetMapping("{workspace-id}/group-chatroom")
+    fun findGroupChatRoom(
+        @PathVariable("workspace-id") workspaceId: Long,
+        @AuthenticationPrincipal token: JwtAuthentication,
+    ): ResponseEntity<ChatRoomResponse> =
+        ResponseEntity.ok().body(
+            ChatRoomResponse.of(
+                workspaceFacadeService.getGroupChatRoom(workspaceId, token.id),
+            ),
         )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -52,7 +52,7 @@ class WorkspaceController(
         )
 
     @GetMapping("{workspace-id}/group-chat-room")
-    fun findGroupChatRoom(
+    override fun getGroupChatRoom(
         @PathVariable("workspace-id") workspaceId: Long,
         @AuthenticationPrincipal token: JwtAuthentication,
     ): ResponseEntity<ChatRoomResponse> =

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
@@ -1,18 +1,20 @@
 package com.backgu.amaker.workspace.controller
 
+import com.backgu.amaker.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.security.JwtAuthentication
 import com.backgu.amaker.workspace.dto.request.WorkspaceCreateRequest
 import com.backgu.amaker.workspace.dto.response.WorkspaceResponse
 import com.backgu.amaker.workspace.dto.response.WorkspacesResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 
 @Tag(name = "workspaces", description = "워크스페이스 API")
 interface WorkspaceSwagger {
@@ -41,7 +43,6 @@ interface WorkspaceSwagger {
             ),
         ],
     )
-    @GetMapping
     fun findWorkspaces(
         @Parameter(hidden = true) token: JwtAuthentication,
     ): ResponseEntity<WorkspacesResponse>
@@ -56,8 +57,24 @@ interface WorkspaceSwagger {
             ),
         ],
     )
-    @GetMapping("/default")
     fun getDefaultWorkspace(
         @Parameter(hidden = true) token: JwtAuthentication,
     ): ResponseEntity<WorkspaceResponse>
+
+    @Operation(summary = "그룹 채팅방 조회", description = "워크스페이스의 그룹 채팅방을 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "그룹 채팅방 조회 성공",
+                content = [Content(schema = Schema(implementation = ChatRoomResponse::class))],
+            ),
+        ],
+    )
+    fun getGroupChatRoom(
+        @PathVariable
+        @Parameter(description = "워크스페이스 ID", required = true, `in` = ParameterIn.PATH)
+        workspaceId: Long,
+        @Parameter(hidden = true) token: JwtAuthentication,
+    ): ResponseEntity<ChatRoomResponse>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
@@ -10,4 +10,9 @@ interface WorkspaceUserRepository : JpaRepository<WorkspaceUserEntity, Long> {
     fun findWorkspaceIdsByUserId(
         @Param("userId") userId: String,
     ): List<Long>
+
+    fun existsByUserIdAndWorkspaceId(
+        userId: String,
+        workspaceId: Long,
+    ): Boolean
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -1,6 +1,8 @@
 package com.backgu.amaker.workspace.service
 
 import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.chat.dto.ChatRoomDto
 import com.backgu.amaker.chat.service.ChatRoomService
 import com.backgu.amaker.chat.service.ChatRoomUserService
 import com.backgu.amaker.user.domain.User
@@ -51,5 +53,17 @@ class WorkspaceFacadeService(
     fun getDefaultWorkspace(userId: String): WorkspaceDto {
         val user: User = userService.getById(userId)
         return workspaceService.getDefaultWorkspaceByUserId(user).let { WorkspaceDto.of(it) }
+    }
+
+    fun getGroupChatRoom(
+        workspaceId: Long,
+        userId: String,
+    ): ChatRoomDto {
+        val user: User = userService.getById(userId)
+        val workspace: Workspace = workspaceService.getWorkspaceById(workspaceId)
+
+        workspaceUserService.validUserInWorkspace(user, workspace)
+
+        return ChatRoomDto.of(chatRoomService.getGroupChatRoomByWorkspace(workspace, ChatRoomType.GROUP))
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -1,7 +1,6 @@
 package com.backgu.amaker.workspace.service
 
 import com.backgu.amaker.chat.domain.ChatRoom
-import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.chat.dto.ChatRoomDto
 import com.backgu.amaker.chat.service.ChatRoomService
 import com.backgu.amaker.chat.service.ChatRoomUserService
@@ -64,6 +63,6 @@ class WorkspaceFacadeService(
 
         workspaceUserService.validUserInWorkspace(user, workspace)
 
-        return ChatRoomDto.of(chatRoomService.getGroupChatRoomByWorkspace(workspace, ChatRoomType.GROUP))
+        return ChatRoomDto.of(chatRoomService.getGroupChatRoomByWorkspace(workspace))
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
@@ -6,6 +6,7 @@ import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import com.backgu.amaker.workspace.repository.WorkspaceRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -31,5 +32,12 @@ class WorkspaceService(
         workspaceRepository.getDefaultWorkspaceByUserId(user.id)?.toDomain() ?: run {
             logger.error { "Default workspace not found : ${user.id}" }
             throw EntityNotFoundException("Default workspace not found : ${user.id}")
+        }
+
+    fun getWorkspaceById(workspaceId: Long): Workspace =
+        // TODO : 공통 에러처리 추후에 해줘야함
+        workspaceRepository.findByIdOrNull(workspaceId)?.toDomain() ?: run {
+            logger.error { "Workspace not found : $workspaceId" }
+            throw EntityNotFoundException("Workspace not found : $workspaceId")
         }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
@@ -1,11 +1,16 @@
 package com.backgu.amaker.workspace.service
 
 import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.domain.WorkspaceUser
 import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 @Transactional(readOnly = true)
@@ -16,4 +21,14 @@ class WorkspaceUserService(
     fun save(workspaceUser: WorkspaceUser): WorkspaceUser = workspaceUserRepository.save(WorkspaceUserEntity.of(workspaceUser)).toDomain()
 
     fun findWorkspaceIdsByUser(user: User): List<Long> = workspaceUserRepository.findWorkspaceIdsByUserId(user.id)
+
+    fun validUserInWorkspace(
+        user: User,
+        workspace: Workspace,
+    ) {
+        if (!workspaceUserRepository.existsByUserIdAndWorkspaceId(user.id, workspace.id)) {
+            logger.error { "User ${user.id} is not in Workspace ${workspace.id}" }
+            throw EntityNotFoundException("User ${user.id} is not in Workspace ${workspace.id}")
+        }
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -4,7 +4,8 @@ import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.fixture.WorkspaceFixture.Companion.createWorkspaceRequest
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
 import jakarta.persistence.EntityNotFoundException
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -113,8 +113,7 @@ class WorkspaceFacadeServiceTest {
         val result = workspaceFacadeService.getGroupChatRoom(workspace.id, userId)
 
         // then
-        assertThat(result.chatRoomDto.chatRoomId).isEqualTo(chatRoom.id)
-        assertThat(result.workspaceName).isEqualTo("워크스페이스1")
+        assertThat(result.chatRoomId).isEqualTo(chatRoom.id)
     }
 
     companion object {

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -4,10 +4,9 @@ import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.fixture.WorkspaceFixture.Companion.createWorkspaceRequest
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
 import jakarta.persistence.EntityNotFoundException
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
@@ -90,11 +89,9 @@ class WorkspaceFacadeServiceTest {
         fixtures.user.createPersistedUser(userId)
 
         // when & then
-        assertThrows<EntityNotFoundException> {
-            workspaceFacadeService.getDefaultWorkspace(userId)
-        }.message.let {
-            assertThat(it).isEqualTo("Default workspace not found : $userId")
-        }
+        assertThatThrownBy { workspaceFacadeService.getDefaultWorkspace(userId) }
+            .isInstanceOf(EntityNotFoundException::class.java)
+            .hasMessage("Default workspace not found : $userId")
     }
 
     @Test

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -1,8 +1,8 @@
 package com.backgu.amaker.workspace.service
 
+import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.fixture.WorkspaceFixture.Companion.createWorkspaceRequest
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
-import com.backgu.amaker.user.domain.User
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
@@ -44,7 +44,7 @@ class WorkspaceFacadeServiceTest {
     fun findWorkspaces() {
         // given
         val userId = "tester"
-        val user: User = fixtures.user.createPersistedUser(userId)
+        fixtures.user.createPersistedUser(userId)
         val workspace1 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
         fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace1.id, leaderId = userId)
         val workspace2 = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스2")
@@ -95,6 +95,26 @@ class WorkspaceFacadeServiceTest {
         }.message.let {
             assertThat(it).isEqualTo("Default workspace not found : $userId")
         }
+    }
+
+    @Test
+    @DisplayName("워크스페이스의 그룹 채팅방을 조회")
+    fun getGroupChatRoom() {
+        // given
+        val userId = "tester"
+        fixtures.user.createPersistedUser(userId)
+        val workspace = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = userId)
+        val chatRoom =
+            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+        fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(userId))
+
+        // when
+        val result = workspaceFacadeService.getGroupChatRoom(workspace.id, userId)
+
+        // then
+        assertThat(result.chatRoomDto.chatRoomId).isEqualTo(chatRoom.id)
+        assertThat(result.workspaceName).isEqualTo("워크스페이스1")
     }
 
     companion object {

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
@@ -1,0 +1,66 @@
+package com.backgu.amaker.workspace.service
+
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.fixture.WorkspaceFixtureFacade
+import com.backgu.amaker.user.domain.User
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.Test
+
+@DisplayName("WorkspaceUserService 테스트")
+@Transactional
+@SpringBootTest
+class WorkspaceUserServiceTest {
+    @Autowired
+    lateinit var workspaceUserService: WorkspaceUserService
+
+    @Autowired
+    lateinit var fixtures: WorkspaceFixtureFacade
+
+    @Test
+    @DisplayName("유저가 속한 워크스페이스의 그룹 채팅방 조회 성공")
+    fun getGroupChatRoomIn() {
+        // given
+        val userId = "tester"
+        val user = fixtures.user.createPersistedUser(userId)
+        val workspace = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = userId)
+        val chatRoom =
+            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+        fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(userId))
+
+        // when & then
+        assertDoesNotThrow {
+            workspaceUserService.validUserInWorkspace(user, workspace)
+        }
+    }
+
+    @Test
+    @DisplayName("유저가 속하지 않는 워크스페이스의 그룹 채팅방 조회 실패")
+    fun failGetGroupChatRoomNotIn() {
+        // given
+        val userId = "tester"
+        val user: User = fixtures.user.createPersistedUser(userId)
+
+        val diffUser = "diff tester"
+        fixtures.user.createPersistedUser(diffUser)
+        val workspace = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = diffUser)
+        val chatRoom =
+            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+        fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(diffUser))
+
+        // when & then
+        assertThrows<EntityNotFoundException> {
+            workspaceUserService.validUserInWorkspace(user, workspace)
+        }.message.let {
+            assertThat(it).isEqualTo("User ${user.id} is not in Workspace ${workspace.id}")
+        }
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
@@ -4,10 +4,9 @@ import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
 import com.backgu.amaker.user.domain.User
 import jakarta.persistence.EntityNotFoundException
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
@@ -36,9 +35,9 @@ class WorkspaceUserServiceTest {
         fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(userId))
 
         // when & then
-        assertDoesNotThrow {
+        assertThatCode {
             workspaceUserService.validUserInWorkspace(user, workspace)
-        }
+        }.doesNotThrowAnyException()
     }
 
     @Test
@@ -57,10 +56,8 @@ class WorkspaceUserServiceTest {
         fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(diffUser))
 
         // when & then
-        assertThrows<EntityNotFoundException> {
-            workspaceUserService.validUserInWorkspace(user, workspace)
-        }.message.let {
-            assertThat(it).isEqualTo("User ${user.id} is not in Workspace ${workspace.id}")
-        }
+        assertThatThrownBy { workspaceUserService.validUserInWorkspace(user, workspace) }
+            .isInstanceOf(EntityNotFoundException::class.java)
+            .hasMessage("User ${user.id} is not in Workspace ${workspace.id}")
     }
 }


### PR DESCRIPTION
# Why
테스트 코드 작성과 Dto와 Response를 어떤 방식으로 줘야될지
고민을 하다보니 시간이 생각보다 더 걸림

# How
`WorkspaceGroupChatRoomResponse` 와 같은 형태로 Response를 따로 만들어서
줘야 될까를 고민하다
엔드포인트가 {workspace-id}/group-chat-room 형식이기 때문에
`ChatRoomResponse` 으로 줘도 괜찮다고 생각했음

# Result
![image](https://github.com/soma-baekgu/A-Maker-BE/assets/48712043/51c200ad-7e04-4514-bc2c-d5257e493efa)

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/48712043/ed433fc2-369d-4386-9c04-274d22ffd45c)

`WorkspaceUserServiceTest` 에서
`WorkspaceFixtureFacade` 를 가져와서 사용하고 있는데
이게 맞는 방식인지 모르겠음

# Prize
확실히 `FacadeService` 를 이용하니 코드가 깔끔해 지는듯

# Link
BG-202