### PR TITLE
[BG-174]: 링크를 통해 워크스페이스를 가입할 수 있는 API를 개발 (3h / 4h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
@@ -3,14 +3,10 @@ package com.backgu.amaker.chat.repository
 import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 
 interface ChatRoomRepository : JpaRepository<ChatRoomEntity, Long> {
     fun findByWorkspaceIdAndChatRoomType(
         workspaceId: Long,
         chatRoomType: ChatRoomType,
     ): ChatRoomEntity?
-
-    @Query("select cr from ChatRoom cr where cr.workspaceId = :workspaceId and cr.chatRoomType = 'GROUP'")
-    fun findByWorkspaceId(workspaceId: Long): List<ChatRoomEntity>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomRepository.kt
@@ -2,5 +2,9 @@ package com.backgu.amaker.chat.repository
 
 import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface ChatRoomRepository : JpaRepository<ChatRoomEntity, Long>
+interface ChatRoomRepository : JpaRepository<ChatRoomEntity, Long> {
+    @Query("select cr from ChatRoom cr where cr.workspaceId = :workspaceId and cr.chatRoomType = 'GROUP'")
+    fun findByWorkspaceId(workspaceId: Long): List<ChatRoomEntity>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -13,4 +13,7 @@ class ChatRoomService(
 ) {
     @Transactional
     fun save(chatRoom: ChatRoom): ChatRoom = chatRoomRepository.save(ChatRoomEntity.of(chatRoom)).toDomain()
+
+    fun findGroupChatRoomByWorkspaceId(workspaceId: Long): List<ChatRoom> =
+        chatRoomRepository.findByWorkspaceId(workspaceId).map { it.toDomain() }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -28,6 +28,7 @@ class ChatRoomService(
                 throw EntityNotFoundException("Group ChatRoom not found in Workspace ${workspace.id}")
             }
 
-    fun findGroupChatRoomByWorkspaceId(workspaceId: Long): List<ChatRoom> =
-        chatRoomRepository.findByWorkspaceId(workspaceId).map { it.toDomain() }
+    fun findGroupChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
+        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.GROUP)?.toDomain()
+            ?: throw EntityNotFoundException("Group ChatRoom not found in Workspace $workspaceId")
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -8,7 +8,9 @@ import com.backgu.amaker.workspace.service.WorkspaceFacadeService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -48,4 +50,14 @@ class WorkspaceController(
         ResponseEntity.ok().body(
             WorkspaceResponse.of(workspaceFacadeService.getDefaultWorkspace(token.id)),
         )
+
+    @PutMapping("/{workspaceId}/invite/activate")
+    override fun activateWorkspaceInvite(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable workspaceId: Long,
+    ): ResponseEntity<Unit> {
+        workspaceFacadeService.activateWorkspaceUser(token.id, workspaceId)
+        return ResponseEntity.noContent().build()
+    }
+
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -59,5 +59,4 @@ class WorkspaceController(
         workspaceFacadeService.activateWorkspaceUser(token.id, workspaceId)
         return ResponseEntity.noContent().build()
     }
-
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.workspace.controller
 
 import com.backgu.amaker.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.security.JwtAuthentication
+import com.backgu.amaker.workspace.dto.WorkspaceUserDto
 import com.backgu.amaker.workspace.dto.request.WorkspaceCreateRequest
 import com.backgu.amaker.workspace.dto.response.WorkspaceResponse
 import com.backgu.amaker.workspace.dto.response.WorkspacesResponse
@@ -63,12 +64,9 @@ class WorkspaceController(
             ),
         )
 
-    @PutMapping("/{workspaceId}/invite/activate")
+    @PutMapping("/{workspace-id}/invite/activate")
     override fun activateWorkspaceInvite(
         @AuthenticationPrincipal token: JwtAuthentication,
-        @PathVariable workspaceId: Long,
-    ): ResponseEntity<Unit> {
-        workspaceFacadeService.activateWorkspaceUser(token.id, workspaceId)
-        return ResponseEntity.noContent().build()
-    }
+        @PathVariable("workspace-id") workspaceId: Long,
+    ): ResponseEntity<WorkspaceUserDto> = ResponseEntity.ok().body(workspaceFacadeService.activateWorkspaceUser(token.id, workspaceId))
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
 
 @Tag(name = "workspaces", description = "워크스페이스 API")
 interface WorkspaceSwagger {
@@ -41,7 +40,6 @@ interface WorkspaceSwagger {
             ),
         ],
     )
-    @GetMapping
     fun findWorkspaces(
         @Parameter(hidden = true) token: JwtAuthentication,
     ): ResponseEntity<WorkspacesResponse>
@@ -56,8 +54,22 @@ interface WorkspaceSwagger {
             ),
         ],
     )
-    @GetMapping("/default")
     fun getDefaultWorkspace(
         @Parameter(hidden = true) token: JwtAuthentication,
     ): ResponseEntity<WorkspaceResponse>
+
+    @Operation(summary = "워크스페이스 유저 활성화", description = "워크스페이스에 대해 초대된 사용자가 초대를 수락합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "워크스페이스 유저 활성화 성공",
+                content = [Content(schema = Schema(implementation = Unit::class))],
+            ),
+        ],
+    )
+    fun activateWorkspaceInvite(
+        @Parameter(hidden = true) token: JwtAuthentication,
+        workspaceId: Long,
+    ): ResponseEntity<Unit>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.workspace.controller
 
 import com.backgu.amaker.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.security.JwtAuthentication
+import com.backgu.amaker.workspace.dto.WorkspaceUserDto
 import com.backgu.amaker.workspace.dto.request.WorkspaceCreateRequest
 import com.backgu.amaker.workspace.dto.response.WorkspaceResponse
 import com.backgu.amaker.workspace.dto.response.WorkspacesResponse
@@ -91,5 +92,5 @@ interface WorkspaceSwagger {
     fun activateWorkspaceInvite(
         @Parameter(hidden = true) token: JwtAuthentication,
         workspaceId: Long,
-    ): ResponseEntity<Unit>
+    ): ResponseEntity<WorkspaceUserDto>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceUserDto.kt
@@ -1,0 +1,21 @@
+package com.backgu.amaker.workspace.dto
+
+import com.backgu.amaker.workspace.domain.WorkspaceUser
+import com.backgu.amaker.workspace.domain.WorkspaceUserStatus
+
+class WorkspaceUserDto(
+    val userId: String,
+    val workspaceId: Long,
+    val workspaceRole: String,
+    val status: WorkspaceUserStatus,
+) {
+    companion object {
+        fun of(workspaceUser: WorkspaceUser): WorkspaceUserDto =
+            WorkspaceUserDto(
+                userId = workspaceUser.userId,
+                workspaceId = workspaceUser.workspaceId,
+                workspaceRole = workspaceUser.workspaceRole.value,
+                status = workspaceUser.status,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/repository/WorkspaceUserRepository.kt
@@ -10,4 +10,10 @@ interface WorkspaceUserRepository : JpaRepository<WorkspaceUserEntity, Long> {
     fun findWorkspaceIdsByUserId(
         @Param("userId") userId: String,
     ): List<Long>
+
+    @Query("select wu from WorkspaceUser wu where wu.userId = :userId and wu.workspaceId = :workspaceId")
+    fun findByUserIdAndWorkspaceId(
+        userId: String,
+        workspaceId: Long,
+    ): WorkspaceUserEntity?
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -9,6 +9,7 @@ import com.backgu.amaker.user.service.UserService
 import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
 import com.backgu.amaker.workspace.dto.WorkspaceDto
+import com.backgu.amaker.workspace.dto.WorkspaceUserDto
 import com.backgu.amaker.workspace.dto.WorkspacesDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -70,7 +71,7 @@ class WorkspaceFacadeService(
     fun activateWorkspaceUser(
         userId: String,
         workspaceId: Long,
-    ) {
+    ): WorkspaceUserDto {
         val user = userService.getById(userId)
         val workspace = workspaceService.getById(workspaceId)
 
@@ -80,6 +81,8 @@ class WorkspaceFacadeService(
 
         chatRoomService
             .findGroupChatRoomByWorkspaceId(workspaceId)
-            .forEach { chatRoomUserService.save(it.addUser(user)) }
+            .addUser(user)
+
+        return WorkspaceUserDto.of(workspaceUser)
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -52,4 +52,19 @@ class WorkspaceFacadeService(
         val user: User = userService.getById(userId)
         return workspaceService.getDefaultWorkspaceByUserId(user).let { WorkspaceDto.of(it) }
     }
+
+    @Transactional
+    fun activateWorkspaceUser(
+        userId: String,
+        workspaceId: Long,
+    ) {
+        val user = userService.getById(userId)
+        val workspace = workspaceService.getById(workspaceId)
+
+        val workspaceUser = workspaceUserService.getWorkspaceUser(workspace, user)
+        workspaceUser.activate()
+        workspaceUserService.save(workspaceUser)
+
+        chatRoomService.findGroupChatRoomByWorkspaceId(workspaceId).forEach { chatRoomUserService.save(it.addUser(user)) }
+    }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
@@ -6,6 +6,7 @@ import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import com.backgu.amaker.workspace.repository.WorkspaceRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,6 +22,12 @@ class WorkspaceService(
         val saveWorkspace = workspaceRepository.save(WorkspaceEntity.of(workspace))
         return saveWorkspace.toDomain()
     }
+
+    fun getById(id: Long): Workspace =
+        workspaceRepository.findByIdOrNull(id)?.toDomain() ?: run {
+            logger.error { "Workspace not found : $id" }
+            throw EntityNotFoundException("Workspace not found : $id")
+        }
 
     fun getWorkspaceByIds(workspaceIds: List<Long>): List<Workspace> =
         workspaceRepository.findByWorkspaceIds(workspaceIds).map {

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.workspace.service
 
 import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.domain.WorkspaceUser
 import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
@@ -16,4 +17,14 @@ class WorkspaceUserService(
     fun save(workspaceUser: WorkspaceUser): WorkspaceUser = workspaceUserRepository.save(WorkspaceUserEntity.of(workspaceUser)).toDomain()
 
     fun findWorkspaceIdsByUser(user: User): List<Long> = workspaceUserRepository.findWorkspaceIdsByUserId(user.id)
+
+    @Transactional
+    fun getWorkspaceUser(
+        workspace: Workspace,
+        user: User,
+    ): WorkspaceUser =
+        workspaceUserRepository
+            .findByUserIdAndWorkspaceId(workspaceId = workspace.id, userId = user.id)
+            ?.toDomain()
+            ?: throw IllegalArgumentException("User is not a member of the workspace")
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
@@ -28,4 +28,8 @@ class ChatRoomFixture(
         (1..count).map {
             createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = chatRoomType ?: ChatRoomType.GROUP)
         }
+
+    fun deleteAll() {
+        chatRoomRepository.deleteAll()
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomUserFixture.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class ChatRoomUserFixture(
-    private val chatRoomUserRepository: ChatRoomUserRepository,
+    val chatRoomUserRepository: ChatRoomUserRepository,
 ) {
     fun createPersistedChatRoomUser(
         chatRoomId: Long,
@@ -21,4 +21,8 @@ class ChatRoomUserFixture(
                     ),
                 )
         }
+
+    fun deleteAll() {
+        chatRoomUserRepository.deleteAll()
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/UserFixture.kt
@@ -46,4 +46,8 @@ class UserFixture(
     fun createPersistedUsers(count: Long): List<User> = (1..count).map { createPersistedUser(id = it) }
 
     fun createPersistedUsers(vararg ids: Any): List<User> = ids.map { createPersistedUser(it.toString()) }
+
+    fun deleteAll() {
+        userRepository.deleteAll()
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
@@ -40,4 +40,8 @@ class WorkspaceFixture(
         .save(
             createWorkspace(name = name, thumbnail = thumbnail),
         ).toDomain()
+
+    fun deleteAll() {
+        workspaceRepository.deleteAll()
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixtureFacade.kt
@@ -36,4 +36,12 @@ class WorkspaceFixtureFacade(
             )
         }
     }
+
+    fun deleteAll() {
+        chatRoom.deleteAll()
+        chatRoomUser.deleteAll()
+        workspace.deleteAll()
+        workspaceUser.deleteAll()
+        user.deleteAll()
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
@@ -39,4 +39,8 @@ class WorkspaceUserFixture(
 
         return workspaceUsers
     }
+
+    fun deleteAll() {
+        workspaceUserRepository.deleteAll()
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/user/domain/UserTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/user/domain/UserTest.kt
@@ -1,0 +1,23 @@
+package com.backgu.amaker.user.domain
+
+import com.backgu.amaker.workspace.domain.Workspace
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("User 테스트")
+class UserTest {
+    @Test
+    fun createWorkspace() {
+        // given
+        val user =
+            User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
+
+        // when
+        val workspace: Workspace = user.createWorkspace(name = "workspace1")
+
+        // then
+        assertThat(workspace).isNotNull
+        assertThat(workspace.name).isEqualTo("workspace1")
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.workspace.service
 
+import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.fixture.WorkspaceFixture.Companion.createWorkspaceRequest
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
@@ -127,8 +128,12 @@ class WorkspaceFacadeServiceTest {
             memberIds = listOf(memberId),
         )
 
+        val chatRoom: ChatRoom =
+            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+        fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(leaderId))
+
         // when
-        workspaceFacadeService.activateWorkspaceUser(memberId, workspace.id)
+        val result = workspaceFacadeService.activateWorkspaceUser(memberId, workspace.id)
         val workspaceUser: WorkspaceUser = workspaceUserService.getWorkspaceUser(workspace, member)
 
         // then

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
@@ -10,7 +10,7 @@ class Workspace(
     var name: String,
     var thumbnail: String = "/images/default_thumbnail.png",
 ) : BaseTime() {
-    fun assignLeader(user: User): WorkspaceUser = WorkspaceUser(userId = user.id, workspaceId = id, workspaceRole = WorkspaceRole.LEADER)
+    fun assignLeader(user: User): WorkspaceUser = WorkspaceUser.makeWorkspaceLeader(workspace = this, user = user)
 
     fun createGroupChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.GROUP)
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -1,10 +1,29 @@
 package com.backgu.amaker.workspace.domain
 
 import com.backgu.amaker.common.domain.BaseTime
+import com.backgu.amaker.user.domain.User
 
 class WorkspaceUser(
     val id: Long = 0L,
     val userId: String,
     val workspaceId: Long,
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
-) : BaseTime()
+    var status: WorkspaceUserStatus,
+) : BaseTime() {
+    fun activate() {
+        this.status = WorkspaceUserStatus.ACTIVE
+    }
+
+    companion object {
+        fun makeWorkspaceLeader(
+            workspace: Workspace,
+            user: User,
+        ): WorkspaceUser =
+            WorkspaceUser(
+                userId = user.id,
+                workspaceId = workspace.id,
+                workspaceRole = WorkspaceRole.LEADER,
+                status = WorkspaceUserStatus.ACTIVE,
+            )
+    }
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceUserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/jpa/WorkspaceUserEntity.kt
@@ -3,6 +3,7 @@ package com.backgu.amaker.workspace.jpa
 import com.backgu.amaker.common.jpa.BaseTimeEntity
 import com.backgu.amaker.workspace.domain.WorkspaceRole
 import com.backgu.amaker.workspace.domain.WorkspaceUser
+import com.backgu.amaker.workspace.domain.WorkspaceUserStatus
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -25,6 +26,9 @@ class WorkspaceUserEntity(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: WorkspaceUserStatus = WorkspaceUserStatus.PENDING,
 ) : BaseTimeEntity() {
     fun toDomain(): WorkspaceUser =
         WorkspaceUser(
@@ -32,6 +36,7 @@ class WorkspaceUserEntity(
             userId = userId,
             workspaceId = workspaceId,
             workspaceRole = workspaceRole,
+            status = status,
         )
 
     companion object {
@@ -41,6 +46,7 @@ class WorkspaceUserEntity(
                 userId = workspaceUser.userId,
                 workspaceId = workspaceUser.workspaceId,
                 workspaceRole = workspaceUser.workspaceRole,
+                status = workspaceUser.status,
             )
     }
 }

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
@@ -1,0 +1,28 @@
+package com.backgu.amaker.chat.domain
+
+import com.backgu.amaker.user.domain.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("ChatRoom 테스트")
+class ChatRoomTest {
+    @Test
+    @DisplayName("채팅방에 사용자를 추가할 수 있다")
+    fun addUser() {
+        // given
+        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.GROUP)
+        val user1 =
+            User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
+        val user2 =
+            User(id = "user2", name = "user2", email = "user2@gmail.com", picture = "/images/default_thumbnail.png")
+
+        // when
+        val chatRoomUser: ChatRoomUser = chatRoom.addUser(user = user1)
+
+        // then
+        assertThat(chatRoomUser).isNotNull
+        assertThat(chatRoomUser.userId).isEqualTo("user1")
+        assertThat(chatRoomUser.chatRoomId).isEqualTo(chatRoom.id)
+    }
+}

--- a/domain/src/test/kotlin/com/backgu/amaker/workspace/domain/WorkspaceTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/workspace/domain/WorkspaceTest.kt
@@ -1,0 +1,48 @@
+package com.backgu.amaker.workspace.domain
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.user.domain.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Workspace 테스트")
+class WorkspaceTest {
+    @Test
+    @DisplayName("워크스페이스에서 leader를 배정할 수 있다")
+    fun assignLeader() {
+        // given
+        val workspace = Workspace(name = "test")
+        val leader =
+            User(id = "leader", name = "leader", email = "leader@gmail.com", picture = "/images/default_thumbnail.png")
+
+        // when
+        val workspaceUser: WorkspaceUser = workspace.assignLeader(leader)
+
+        // then
+        assertThat(workspaceUser).isNotNull
+        assertThat(workspaceUser.workspaceRole).isEqualTo(WorkspaceRole.LEADER)
+        assertThat(workspaceUser.status).isEqualTo(WorkspaceUserStatus.ACTIVE)
+        assertThat(workspaceUser.userId).isEqualTo(leader.id)
+        assertThat(workspaceUser.workspaceId).isEqualTo(workspace.id)
+    }
+
+    @Test
+    @DisplayName("워크스페이스에서 그룹 채팅방을 생성할 수 있다")
+    fun createGroupChatRoom() {
+        // given
+        val workspace = Workspace(name = "test")
+        val leader =
+            User(id = "leader", name = "leader", email = "leader@gmail.com", picture = "/images/default_thumbnail.png")
+        workspace.assignLeader(leader)
+
+        // when
+        val chatRoom: ChatRoom = workspace.createGroupChatRoom()
+
+        // then
+        assertThat(chatRoom).isNotNull
+        assertThat(chatRoom.workspaceId).isEqualTo(workspace.id)
+        assertThat(chatRoom.chatRoomType).isEqualTo(ChatRoomType.GROUP)
+    }
+}

--- a/domain/src/test/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUserTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUserTest.kt
@@ -1,0 +1,27 @@
+package com.backgu.amaker.workspace.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("WorkspaceUser 테스트")
+class WorkspaceUserTest {
+    @Test
+    @DisplayName("워크스페이스 리더 생성")
+    fun makeWorkspaceLeader() {
+        // given
+        val workspaceUser =
+            WorkspaceUser(
+                userId = "member",
+                workspaceId = 1,
+                workspaceRole = WorkspaceRole.MEMBER,
+                status = WorkspaceUserStatus.PENDING,
+            )
+
+        // when
+        workspaceUser.activate()
+
+        // then
+        assertThat(workspaceUser.status).isEqualTo(WorkspaceUserStatus.ACTIVE)
+    }
+}


### PR DESCRIPTION
# Why

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/b57b3661-f0f0-4709-8c18-8e116c3236c3)

* 초기에 유저를 초대하면 `PENDING` 상태이다.
* 유저는 이를 확인하고 초대에 응하면 'ACTIVE' 상태로 수정해야한다.
* `workspace_user` 테이블에 'ACTIVE'로 마킹되면 그때 워크스페이스의 유저로 인정한다.

# How

이 서비스에 가입되어 있지 않은 사용자를 어떻게 할지 고민을 했다.

처음에는 `redis`를 활용해서 풀어나가 볼까 고민했다.
* `{IDENTIFICATION_CODE}:이메일,{worspaceId}` 을 저장해놓는다.
* 해당 레코드의 `expiration`을 3시간으로 지정한다.
* 사용자가 `POST http://a-maker.com/api/v1/invite/{IDENTIFICATION_CODE}` 로 요청을 보낸다.
* 서버는 해당 `IDENTIFICATION_CODE`에 대한 email과 `workspaceId`를 꺼내서 `ACTIVE`로 변환한다.

하지만 일단 빠르게 구현하기 위해 서비스에 가입된 사용자만 호출 할 수 있도록 합의했다.

# Result

```kotlin
class WorkspaceUser(
    val id: Long = 0L,
    val userId: String,
    val workspaceId: Long,
    var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
    var status: WorkspaceUserStatus,
) : BaseTime() {
    fun activate() {
        this.status = WorkspaceUserStatus.ACTIVE
    }
}

class Workspace(
    val id: Long = 0L,
    var name: String,
    var thumbnail: String = "/images/default_thumbnail.png",
) : BaseTime() {
    fun assignLeader(user: User): WorkspaceUser = WorkspaceUser.makeWorkspaceLeader(workspace = this, user = user)

    fun createGroupChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.GROUP)
}
```

현재 많이 가볍지만 도메인 클래스에 최대한 의미 있는 메서드를 담아보려했다.

또 각각의 `POJO`로 구성된 도메인 클래스에 대한 유닛 테스트도 작성했다.

# Prize

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/00d8124c-858b-4fe4-8c80-d01e338d367f)


# Reference

BG-174