### PR TITLE
[BG-161]: API 래퍼 정의하기 (3h / 3h)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("com.auth0:java-jwt:3.18.3")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")

--- a/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiController.kt
@@ -4,6 +4,8 @@ import com.backgu.amaker.auth.config.AuthConfig
 import com.backgu.amaker.auth.dto.response.JwtTokenResponse
 import com.backgu.amaker.auth.dto.response.OAuthUrlResponse
 import com.backgu.amaker.auth.service.AuthFacadeService
+import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.common.infra.ApiHandler
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,11 +17,14 @@ import org.springframework.web.bind.annotation.RestController
 class AuthApiController(
     val authConfig: AuthConfig,
     val authFacadeService: AuthFacadeService,
+    val apiHandler: ApiHandler,
 ) : AuthApiSwagger {
     @GetMapping("/oauth/google")
-    override fun googleAuth(): ResponseEntity<OAuthUrlResponse> =
+    override fun googleAuth(): ResponseEntity<ApiResult<OAuthUrlResponse>> =
         ResponseEntity.ok().body(
-            OAuthUrlResponse(authConfig.oauthUrl),
+            apiHandler.onSuccess(
+                OAuthUrlResponse(authConfig.oauthUrl),
+            ),
         )
 
     @GetMapping("/code/google")
@@ -28,8 +33,10 @@ class AuthApiController(
         @RequestParam(name = "scope", required = false) scope: String,
         @RequestParam(name = "authuser", required = false) authUser: String,
         @RequestParam(name = "prompt", required = false) prompt: String,
-    ): ResponseEntity<JwtTokenResponse> =
+    ): ResponseEntity<ApiResult<JwtTokenResponse>> =
         ResponseEntity.ok().body(
-            JwtTokenResponse.of(authFacadeService.googleLogin(authorizationCode)),
+            apiHandler.onSuccess(
+                JwtTokenResponse.of(authFacadeService.googleLogin(authorizationCode)),
+            ),
         )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiSwagger.kt
@@ -2,9 +2,8 @@ package com.backgu.amaker.auth.controller
 
 import com.backgu.amaker.auth.dto.response.JwtTokenResponse
 import com.backgu.amaker.auth.dto.response.OAuthUrlResponse
+import com.backgu.amaker.common.dto.response.ApiResult
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.Content
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -18,11 +17,10 @@ interface AuthApiSwagger {
             ApiResponse(
                 responseCode = "200",
                 description = "구글 oauth url 조회 성공",
-                content = [Content(schema = Schema(implementation = OAuthUrlResponse::class))],
             ),
         ],
     )
-    fun googleAuth(): ResponseEntity<OAuthUrlResponse>
+    fun googleAuth(): ResponseEntity<ApiResult<OAuthUrlResponse>>
 
     @Operation(summary = "구글 로그인 요청", description = "구글 로그인을 요청합니다.")
     @ApiResponses(
@@ -30,7 +28,6 @@ interface AuthApiSwagger {
             ApiResponse(
                 responseCode = "200",
                 description = "구글 로그인 성공",
-                content = [Content(schema = Schema(implementation = JwtTokenResponse::class))],
             ),
         ],
     )
@@ -39,5 +36,5 @@ interface AuthApiSwagger {
         scope: String,
         authUser: String,
         prompt: String,
-    ): ResponseEntity<JwtTokenResponse>
+    ): ResponseEntity<ApiResult<JwtTokenResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiError.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiError.kt
@@ -1,0 +1,17 @@
+package com.backgu.amaker.common.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+class ApiError<T>(
+    timestamp: String,
+    path: String,
+    status: Int,
+    data: T,
+    @Schema(description = "에러 reason Phrase", example = "Bad Request")
+    val error: String,
+) : ApiResult<T>(
+        timestamp = timestamp,
+        path = path,
+        status = status,
+        data = data,
+    )

--- a/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiResult.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiResult.kt
@@ -1,0 +1,13 @@
+package com.backgu.amaker.common.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+open class ApiResult<T>(
+    @Schema(description = "KST 응답 타임스탬프", example = "2024-07-02T19:56:05.624+09:00")
+    val timestamp: String,
+    @Schema(description = "응답 status code", example = "200")
+    val status: Int,
+    @Schema(description = "요청 URL", example = "/api/v1/test")
+    val path: String,
+    val data: T,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,23 @@
+package com.backgu.amaker.common.exception
+
+import com.backgu.amaker.common.dto.response.ApiError
+import com.backgu.amaker.common.infra.ApiHandler
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class GlobalExceptionHandler(
+    private val apiHandler: ApiHandler,
+) {
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ApiError<Map<String, String>>> {
+        val errorMap: Map<String, String> =
+            e.bindingResult.fieldErrors.associate { error ->
+                error.field to (error.defaultMessage ?: "Invalid value")
+            }
+
+        return ResponseEntity.badRequest().body(apiHandler.onFailure(errorMap))
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/infra/ApiHandler.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/infra/ApiHandler.kt
@@ -1,0 +1,39 @@
+package com.backgu.amaker.common.infra
+
+import com.backgu.amaker.common.dto.response.ApiError
+import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.common.service.ClockHolder
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+@Component
+class ApiHandler(
+    private val request: HttpServletRequest,
+    private val response: HttpServletResponse,
+    private val clockHolder: ClockHolder,
+) {
+    fun <T> onSuccess(
+        data: T,
+        status: HttpStatus = HttpStatus.OK,
+    ): ApiResult<T> =
+        ApiResult(
+            timestamp = clockHolder.now(),
+            path = request.requestURI,
+            status = status.value(),
+            data = data,
+        )
+
+    fun <T> onFailure(
+        error: T,
+        status: HttpStatus = HttpStatus.BAD_REQUEST,
+    ): ApiError<T> =
+        ApiError<T>(
+            timestamp = clockHolder.now(),
+            path = request.requestURI,
+            status = status.value(),
+            data = error,
+            error = status.reasonPhrase,
+        )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/infra/SystemClockHolder.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/infra/SystemClockHolder.kt
@@ -1,0 +1,19 @@
+package com.backgu.amaker.common.infra
+
+import com.backgu.amaker.common.service.ClockHolder
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+@Component
+class SystemClockHolder : ClockHolder {
+    companion object {
+        private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS+09:00")
+    }
+
+    override fun now(): String {
+        val now = LocalDateTime.now()
+        return now.atZone(ZoneOffset.UTC).format(formatter)
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/service/ClockHolder.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/service/ClockHolder.kt
@@ -1,0 +1,5 @@
+package com.backgu.amaker.common.service
+
+interface ClockHolder {
+    fun now(): String
+}

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -1,10 +1,14 @@
 package com.backgu.amaker.workspace.controller
 
+import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.common.infra.ApiHandler
 import com.backgu.amaker.security.JwtAuthentication
 import com.backgu.amaker.workspace.dto.request.WorkspaceCreateRequest
 import com.backgu.amaker.workspace.dto.response.WorkspaceResponse
 import com.backgu.amaker.workspace.dto.response.WorkspacesResponse
 import com.backgu.amaker.workspace.service.WorkspaceFacadeService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,11 +22,12 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 @RequestMapping("/api/v1/workspaces")
 class WorkspaceController(
     private val workspaceFacadeService: WorkspaceFacadeService,
+    private val apiHandler: ApiHandler,
 ) : WorkspaceSwagger {
     @PostMapping
     override fun createWorkspace(
         @AuthenticationPrincipal token: JwtAuthentication,
-        @RequestBody request: WorkspaceCreateRequest,
+        @RequestBody @Valid request: WorkspaceCreateRequest,
     ): ResponseEntity<Unit> =
         ResponseEntity
             .created(
@@ -36,16 +41,20 @@ class WorkspaceController(
     @GetMapping
     override fun findWorkspaces(
         @AuthenticationPrincipal token: JwtAuthentication,
-    ): ResponseEntity<WorkspacesResponse> =
-        ResponseEntity.ok().body(
-            WorkspacesResponse.of(workspaceFacadeService.findWorkspaces(token.id)),
+    ): ResponseEntity<ApiResult<WorkspacesResponse>> =
+        ResponseEntity.status(HttpStatus.CREATED).body(
+            apiHandler.onSuccess(
+                WorkspacesResponse.of(workspaceFacadeService.findWorkspaces(token.id)),
+            ),
         )
 
     @GetMapping("/default")
     override fun getDefaultWorkspace(
         @AuthenticationPrincipal token: JwtAuthentication,
-    ): ResponseEntity<WorkspaceResponse> =
+    ): ResponseEntity<ApiResult<WorkspaceResponse>> =
         ResponseEntity.ok().body(
-            WorkspaceResponse.of(workspaceFacadeService.getDefaultWorkspace(token.id)),
+            apiHandler.onSuccess(
+                WorkspaceResponse.of(workspaceFacadeService.getDefaultWorkspace(token.id)),
+            ),
         )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
@@ -1,18 +1,19 @@
 package com.backgu.amaker.workspace.controller
 
+import com.backgu.amaker.common.dto.response.ApiResult
 import com.backgu.amaker.security.JwtAuthentication
 import com.backgu.amaker.workspace.dto.request.WorkspaceCreateRequest
 import com.backgu.amaker.workspace.dto.response.WorkspaceResponse
 import com.backgu.amaker.workspace.dto.response.WorkspacesResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Content
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
 
 @Tag(name = "workspaces", description = "워크스페이스 API")
 interface WorkspaceSwagger {
@@ -22,13 +23,12 @@ interface WorkspaceSwagger {
             ApiResponse(
                 responseCode = "201",
                 description = "워크스페이스 생성 성공",
-                content = [Content(schema = Schema(implementation = Unit::class))],
             ),
         ],
     )
     fun createWorkspace(
         @Parameter(hidden = true) token: JwtAuthentication,
-        request: WorkspaceCreateRequest,
+        @RequestBody @Valid request: WorkspaceCreateRequest,
     ): ResponseEntity<Unit>
 
     @Operation(summary = "workspaces 조회", description = "유저가 참여하고 있는 모든 워크스페이스를 조회합니다.")
@@ -37,14 +37,13 @@ interface WorkspaceSwagger {
             ApiResponse(
                 responseCode = "200",
                 description = "워크스페이스 조회 성공",
-                content = [Content(schema = Schema(implementation = WorkspacesResponse::class))],
             ),
         ],
     )
     @GetMapping
     fun findWorkspaces(
         @Parameter(hidden = true) token: JwtAuthentication,
-    ): ResponseEntity<WorkspacesResponse>
+    ): ResponseEntity<ApiResult<WorkspacesResponse>>
 
     @Operation(summary = "기본 workspace 조회", description = "유저가 가장 최근에 참여한 워크스페이스를 조회합니다.")
     @ApiResponses(
@@ -52,12 +51,11 @@ interface WorkspaceSwagger {
             ApiResponse(
                 responseCode = "200",
                 description = "워크스페이스 조회 성공",
-                content = [Content(schema = Schema(implementation = WorkspaceResponse::class))],
             ),
         ],
     )
     @GetMapping("/default")
     fun getDefaultWorkspace(
         @Parameter(hidden = true) token: JwtAuthentication,
-    ): ResponseEntity<WorkspaceResponse>
+    ): ResponseEntity<ApiResult<WorkspaceResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/request/WorkspaceCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/request/WorkspaceCreateRequest.kt
@@ -2,8 +2,10 @@ package com.backgu.amaker.workspace.dto.request
 
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
 
 data class WorkspaceCreateRequest(
+    @field:NotEmpty(message = "워크스페이스 이름은 필수입니다.")
     @Schema(description = "워크스페이스 이름", example = "백구팀 워크스페이스")
     val name: String,
 ) {


### PR DESCRIPTION
# Why

프론트에서 API를 사용하는데 부가적인 정보를 활용하거나, 공통적으로 래핑된 형식이 있으면 처리하기 편리하기 때문에 이를 핸들링하는 계층을 만들었다.

# Result

### 성공 결과

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/9967fb80-7f74-4dce-98bd-2ef546c017a5)

* 응답 시간
* 응답 코드
* 요청 경로
* 응답 데이터

### 실패 결과

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/9e450170-5555-4cd2-b4d8-e49c110e29d2)

* 응답 시간
* 응답 코드
* 요청 경로
* 응답 데이터
  *  에러 메시지들이 `key-val` 형태의 객체로 전달됨



# Link

BG-161