### PR TITLE
[BG-189]: WS 접속 엔드포인트 API를 개발 (3h / 3h)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("com.auth0:java-jwt:3.18.3")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
 
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")

--- a/api/src/main/kotlin/com/backgu/amaker/chat/config/WebSocketConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/config/WebSocketConfig.kt
@@ -1,0 +1,26 @@
+package com.backgu.amaker.chat.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+    override fun configureMessageBroker(config: MessageBrokerRegistry) {
+        config.enableSimpleBroker("/sub")
+        config.setApplicationDestinationPrefixes("/pub")
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry
+            .addEndpoint("/ws")
+            .setAllowedOriginPatterns("*")
+            .withSockJS()
+        registry
+            .addEndpoint("/ws")
+            .setAllowedOriginPatterns("*")
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
@@ -1,0 +1,76 @@
+package com.backgu.amaker.chat.config
+
+import com.backgu.amaker.security.jwt.component.JwtComponent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.lang.Nullable
+import org.springframework.messaging.converter.StringMessageConverter
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.messaging.simp.stomp.StompSessionHandler
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
+import org.springframework.web.socket.WebSocketHttpHeaders
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
+import org.springframework.web.socket.messaging.WebSocketStompClient
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+@DisplayName("웹소켓 설정 테스트")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WebSocketConfigTest {
+    var stompClient: WebSocketStompClient = WebSocketStompClient(StandardWebSocketClient())
+
+    @Autowired
+    lateinit var jwtComponent: JwtComponent
+
+    @LocalServerPort
+    var port: Int = 0
+
+    @Test
+    @DisplayName("웹소켓 연결 테스트")
+    fun testWebSocketConnection() {
+        // given
+        val jwtToken = jwtComponent.create("test", "ROLE_USER")
+        val headers =
+            WebSocketHttpHeaders().apply {
+                add("Authorization", "Bearer $jwtToken")
+            }
+
+        // when
+        val connectFuture: CompletableFuture<StompSession> =
+            stompClient.connectAsync("ws://localhost:$port/ws", headers, stompHandler)
+        val session: StompSession = connectFuture.get(1, TimeUnit.SECONDS)
+
+        // then
+        assertThat(session.isConnected).isTrue()
+    }
+
+    @BeforeEach
+    fun setup() {
+        val webSocketClient = StandardWebSocketClient()
+        stompClient = WebSocketStompClient(webSocketClient)
+        stompClient.messageConverter = StringMessageConverter()
+    }
+
+    private val stompHandler: StompSessionHandler =
+        object : StompSessionHandlerAdapter() {
+            override fun handleException(
+                session: StompSession,
+                @Nullable command: StompCommand?,
+                headers: StompHeaders,
+                payload: ByteArray,
+                exception: Throwable,
+            ) = throw exception
+
+            override fun handleTransportError(
+                session: StompSession,
+                exception: Throwable,
+            ): Unit = throw exception
+        }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -116,7 +116,7 @@ class WorkspaceFacadeServiceTest {
     fun activateWorkspaceUser() {
         // given
         val leaderId = "leader"
-        val leader: User = fixtures.user.createPersistedUser(leaderId)
+        fixtures.user.createPersistedUser(leaderId)
         val workspace = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스")
 
         val memberId = "member"
@@ -133,7 +133,7 @@ class WorkspaceFacadeServiceTest {
         fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(leaderId))
 
         // when
-        val result = workspaceFacadeService.activateWorkspaceUser(memberId, workspace.id)
+        workspaceFacadeService.activateWorkspaceUser(memberId, workspace.id)
         val workspaceUser: WorkspaceUser = workspaceUserService.getWorkspaceUser(workspace, member)
 
         // then
@@ -168,10 +168,10 @@ class WorkspaceFacadeServiceTest {
         // given
         workspaceFixtureFacade.deleteAll()
         val leaderId = "leader"
-        val leader: User = fixtures.user.createPersistedUser(leaderId)
+        fixtures.user.createPersistedUser(leaderId)
 
         val memberId = "member"
-        val member: User = fixtures.user.createPersistedUser(memberId)
+        fixtures.user.createPersistedUser(memberId)
 
         fixtures.workspaceUser.createPersistedWorkspaceUser(
             workspaceId = 0L,

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
@@ -14,8 +14,6 @@ class ChatRoomTest {
         val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.GROUP)
         val user1 =
             User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
-        val user2 =
-            User(id = "user2", name = "user2", email = "user2@gmail.com", picture = "/images/default_thumbnail.png")
 
         // when
         val chatRoomUser: ChatRoomUser = chatRoom.addUser(user = user1)


### PR DESCRIPTION
# Why
사실 3시간이 걸리면 안되는 부분이지만
처음 웹소켓을 사용해서 공부 + 뻘짓을 많이함..

ex) 시큐리티 때문에 연결이 안되던 것을 모르고 뻘짓..

# How
`ws://$domain:$port/ws` 형식으로 엔드포인트를 만들었고
`/pub` `/sub` 형식으로 채팅방에 등록할 예정

# Result
![image](https://github.com/soma-baekgu/A-Maker-BE/assets/48712043/468f6b7a-3cab-4a99-8d46-a94ae3e59c3a)

단순하게 웹 소켓 연결 테스트를 작성함
직접 헤더에 jwt 토큰을 넣어서 인증을 추가하였다

# Prize
웹 소켓을 처음 사용해 보는데 spring이 `stomp`프로토콜을 잘 지원해줘서
생각보다 엔드포인트를 설정할건 없었음

**시큐리티 필터 등에 로그를 잘찍어서 에러의 이유를 확인 할수 있게 하자**

# Reference
* https://dev-gorany.tistory.com/235

위의 블로그를 잘 활용하였음

# Link
BG-189