### PR TITLE
[BG-202]: WS handshake http header 인증 수정 (1.5h / 0.5h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/config/WebSocketConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/config/WebSocketConfig.kt
@@ -1,6 +1,8 @@
 package com.backgu.amaker.chat.config
 
+import com.backgu.amaker.chat.interceptor.JwtChannelInterceptor
 import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
@@ -8,7 +10,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
-class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+class WebSocketConfig(
+    private val jwtChannelInterceptor: JwtChannelInterceptor,
+) : WebSocketMessageBrokerConfigurer {
     override fun configureMessageBroker(config: MessageBrokerRegistry) {
         config.enableSimpleBroker("/sub")
         config.setApplicationDestinationPrefixes("/pub")
@@ -22,5 +26,9 @@ class WebSocketConfig : WebSocketMessageBrokerConfigurer {
         registry
             .addEndpoint("/ws")
             .setAllowedOriginPatterns("*")
+    }
+
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(jwtChannelInterceptor)
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/interceptor/JwtChannelInterceptor.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/interceptor/JwtChannelInterceptor.kt
@@ -1,0 +1,101 @@
+package com.backgu.amaker.chat.interceptor
+
+import com.backgu.amaker.security.JwtAuthentication
+import com.backgu.amaker.security.JwtAuthenticationToken
+import com.backgu.amaker.security.jwt.component.JwtComponent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.security.authentication.InsufficientAuthenticationException
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import java.io.UnsupportedEncodingException
+import java.net.URLDecoder
+import java.util.regex.Pattern
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+class JwtChannelInterceptor(
+    private val jwtComponent: JwtComponent,
+) : ChannelInterceptor {
+    private val bearerRegex: Pattern = Pattern.compile("^Bearer$", Pattern.CASE_INSENSITIVE)
+    private val headerKey: String = "Authorization"
+
+    override fun preSend(
+        message: Message<*>,
+        channel: MessageChannel,
+    ): Message<*> {
+        val headerAccessor = StompHeaderAccessor.wrap(message)
+        logger.info { "전체 메시지: $message" }
+
+        if (StompCommand.CONNECT == headerAccessor.command) {
+            try {
+                val authorizationToken: String =
+                    obtainAuthorizationToken(headerAccessor)
+                        ?: throw InsufficientAuthenticationException("Authorization token is null.")
+
+                val claims: JwtComponent.Claims = jwtComponent.verify(authorizationToken)
+
+                val id: String = claims.id.replace("\"", "")
+                val authorities: List<GrantedAuthority> = obtainAuthorities(claims)
+
+                if (id.isNotEmpty() && authorities.isNotEmpty()) {
+                    val authentication =
+                        JwtAuthenticationToken(
+                            JwtAuthentication(id, authorizationToken),
+                            authorities,
+                        )
+                    SecurityContextHolder.getContext().authentication = authentication
+                } else {
+                    throw InsufficientAuthenticationException("Invalid id or authorities are empty.")
+                }
+            } catch (e: Exception) {
+                logger.error { "인증에 실패했습니다: ${e.message}" }
+                throw InsufficientAuthenticationException("인증에 실패했습니다.", e)
+            }
+        }
+
+        // 메시지를 그대로 반환
+        return message
+    }
+
+    private fun obtainAuthorizationToken(headerAccessor: StompHeaderAccessor): String? =
+        try {
+            val authHeader =
+                headerAccessor.getNativeHeader(headerKey)
+                    ?: throw InsufficientAuthenticationException("Authorization header is missing.")
+
+            var token: String? = authHeader[0]
+            token = URLDecoder.decode(token, "UTF-8")
+            val parts = token.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+            if (parts.size == 2) {
+                val scheme = parts[0]
+                val credentials = parts[1]
+                if (bearerRegex.matcher(scheme).matches()) credentials else null
+            } else {
+                null
+            }
+        } catch (e: UnsupportedEncodingException) {
+            throw InsufficientAuthenticationException("Failed to decode authorization token.", e)
+        }
+
+    private fun obtainAuthorities(claims: JwtComponent.Claims): List<GrantedAuthority> {
+        val roles: Array<String> = claims.roles
+        if (roles.isEmpty()) {
+            throw InsufficientAuthenticationException("Roles are empty in claims.")
+        }
+
+        return roles.map { role ->
+            SimpleGrantedAuthority(role)
+        }
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
@@ -35,6 +35,7 @@ class SecurityConfig(
                         "/swagger-ui/**",
                         "/swagger-resources/**",
                         "/v3/api-docs/**",
+                        "/ws/**",
                     ).permitAll()
                     .anyRequest()
                     .authenticated()

--- a/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
@@ -14,7 +14,6 @@ import org.springframework.messaging.simp.stomp.StompHeaders
 import org.springframework.messaging.simp.stomp.StompSession
 import org.springframework.messaging.simp.stomp.StompSessionHandler
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
-import org.springframework.web.socket.WebSocketHttpHeaders
 import org.springframework.web.socket.client.standard.StandardWebSocketClient
 import org.springframework.web.socket.messaging.WebSocketStompClient
 import java.util.concurrent.CompletableFuture
@@ -36,15 +35,10 @@ class WebSocketConfigTest {
     @DisplayName("웹소켓 연결 테스트")
     fun testWebSocketConnection() {
         // given
-        val jwtToken = jwtComponent.create("test", "ROLE_USER")
-        val headers =
-            WebSocketHttpHeaders().apply {
-                add("Authorization", "Bearer $jwtToken")
-            }
 
         // when
         val connectFuture: CompletableFuture<StompSession> =
-            stompClient.connectAsync("ws://localhost:$port/ws", headers, stompHandler)
+            stompClient.connectAsync("ws://localhost:$port/ws", stompHandler)
         val session: StompSession = connectFuture.get(1, TimeUnit.SECONDS)
 
         // then

--- a/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
@@ -1,10 +1,8 @@
 package com.backgu.amaker.chat.config
 
-import com.backgu.amaker.security.jwt.component.JwtComponent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.lang.Nullable
@@ -24,9 +22,6 @@ import kotlin.test.Test
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class WebSocketConfigTest {
     var stompClient: WebSocketStompClient = WebSocketStompClient(StandardWebSocketClient())
-
-    @Autowired
-    lateinit var jwtComponent: JwtComponent
 
     @LocalServerPort
     var port: Int = 0


### PR DESCRIPTION
# Why
SW 연결시 Http header를 통해 인증을 처리하려 했던 부분 수정

# How
stomp 연결 init handshake시에 jwt 토큰을 Authorization hearder에 주입하여
인증을 처리하려 했음

테스트시에는 `WebSocketHttpHeaders()` 를 이용하여 기능이 통과하였음

하지만 이러한 기능은 클라이언트 상에서 지원하지 않고
제약이 많아 제거하려함

~~`interceptors` 를 활용해 모든 상황에서 jwt를 인증할 수도 있음~~
~~TODO: 어떻게 인증을 해야 될지 고민을 해봐야함~~

interceptors 에서 jwt인증을 확인하는 기능을 추가함

# Result
![image](https://github.com/soma-baekgu/A-Maker-BE/assets/48712043/e0731be2-0d23-4134-a12e-850fc58807d2)

![image](https://github.com/soma-baekgu/A-Maker-BE/assets/48712043/f1f9a13f-30fb-4041-9f49-fd09df07f667)

# Reference
- https://velog.io/@ksp7331/JUnit을-이용한-웹소켓-테스트
- https://velog.io/@tlatldms/Socket-인증-with-API-Gateway-Refresh-JWT

# Link
BG-207