### PR TITLE
[BG-179]: WS에서 채팅방의 메시지를 DB에 저장 기능 구현 (3h / 3)h

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
@@ -1,0 +1,21 @@
+package com.backgu.amaker.chat.controller
+
+import com.backgu.amaker.chat.dto.request.GeneralChatCreateRequest
+import com.backgu.amaker.chat.service.ChatFacadeService
+import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ChatController(
+    private val chatFacadeService: ChatFacadeService,
+) {
+    @MessageMapping("/chat-rooms/{chat-rooms-id}/general")
+    fun sendGeneralChat(
+        @Payload chat: GeneralChatCreateRequest,
+        @DestinationVariable("chat-rooms-id") chatRoomId: Long,
+    ) {
+        chatFacadeService.createGeneralChat(chat.toDto(), chatRoomId)
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatDto.kt
@@ -1,0 +1,28 @@
+package com.backgu.amaker.chat.dto
+
+import com.backgu.amaker.chat.domain.Chat
+import com.backgu.amaker.chat.domain.ChatType
+import java.time.LocalDateTime
+
+data class ChatDto(
+    val id: Long = 0L,
+    val userId: String,
+    val chatRoomId: Long,
+    var content: String,
+    val chatType: ChatType,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun of(chat: Chat): ChatDto =
+            ChatDto(
+                id = chat.id,
+                userId = chat.userId,
+                chatRoomId = chat.chatRoomId,
+                content = chat.content,
+                chatType = chat.chatType,
+                createdAt = chat.createdAt,
+                updatedAt = chat.updatedAt,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/GeneralChatCreateDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/GeneralChatCreateDto.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.chat.dto
+
+data class GeneralChatCreateDto(
+    val userId: String,
+    val content: String,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/request/GeneralChatCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/request/GeneralChatCreateRequest.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.chat.dto.request
+
+import com.backgu.amaker.chat.dto.GeneralChatCreateDto
+
+data class GeneralChatCreateRequest(
+    val userId: String,
+    val content: String,
+) {
+    fun toDto() =
+        GeneralChatCreateDto(
+            userId = userId,
+            content = content,
+        )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRepository.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.chat.repository
+
+import com.backgu.amaker.chat.jpa.ChatEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ChatRepository : JpaRepository<ChatEntity, String>

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
@@ -3,4 +3,9 @@ package com.backgu.amaker.chat.repository
 import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ChatRoomUserRepository : JpaRepository<ChatRoomUserEntity, Long>
+interface ChatRoomUserRepository : JpaRepository<ChatRoomUserEntity, Long> {
+    fun existsByUserIdAndChatRoomId(
+        userId: String,
+        chatRoomId: Long,
+    ): Boolean
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
@@ -1,0 +1,39 @@
+package com.backgu.amaker.chat.service
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.dto.ChatDto
+import com.backgu.amaker.chat.dto.GeneralChatCreateDto
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.user.service.UserService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ChatFacadeService(
+    private val chatRoomService: ChatRoomService,
+    private val chatRoomUserService: ChatRoomUserService,
+    private val chatService: ChatService,
+    private val userService: UserService,
+) {
+    @Transactional
+    fun createGeneralChat(
+        generalChatCreateDto: GeneralChatCreateDto,
+        chatRoomId: Long,
+    ): ChatDto {
+        val user: User = userService.getById(generalChatCreateDto.userId)
+        val chatRoom: ChatRoom = chatRoomService.getById(chatRoomId)
+
+        chatRoomUserService.validateUserInChatRoom(user, chatRoom)
+
+        return ChatDto.of(
+            chatService.save(
+                chatRoom.createGeneralChat(
+                    user = user,
+                    chatRoom = chatRoom,
+                    content = generalChatCreateDto.content,
+                ),
+            ),
+        )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -8,6 +8,8 @@ import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.workspace.domain.Workspace
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -32,4 +34,8 @@ class ChatRoomService(
     fun findGroupChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
         chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.GROUP)?.toDomain()
             ?: throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
+
+    fun getById(chatRoomId: Long): ChatRoom =
+        chatRoomRepository.findByIdOrNull(chatRoomId)?.toDomain()
+            ?: throw EntityNotFoundException("ChatRoom not found $chatRoomId")
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -8,7 +8,6 @@ import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.workspace.domain.Workspace
 import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,10 +31,14 @@ class ChatRoomService(
             }
 
     fun findGroupChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
-        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.GROUP)?.toDomain()
-            ?: throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
+        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.GROUP)?.toDomain() ?: run {
+            logger.error { "Group ChatRoom not found in Workspace $workspaceId" }
+            throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
+        }
 
     fun getById(chatRoomId: Long): ChatRoom =
-        chatRoomRepository.findByIdOrNull(chatRoomId)?.toDomain()
-            ?: throw EntityNotFoundException("ChatRoom not found $chatRoomId")
+        chatRoomRepository.findByIdOrNull(chatRoomId)?.toDomain() ?: run {
+            logger.error { "ChatRoom not found $chatRoomId" }
+            throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
+        }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomUserService.kt
@@ -1,10 +1,16 @@
 package com.backgu.amaker.chat.service
 
+import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomUser
 import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import com.backgu.amaker.chat.repository.ChatRoomUserRepository
+import com.backgu.amaker.user.domain.User
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 @Transactional(readOnly = true)
@@ -13,4 +19,14 @@ class ChatRoomUserService(
 ) {
     @Transactional
     fun save(chatRoomUser: ChatRoomUser): ChatRoomUser = chatRoomUserRepository.save(ChatRoomUserEntity.of(chatRoomUser)).toDomain()
+
+    fun validateUserInChatRoom(
+        user: User,
+        chatRoom: ChatRoom,
+    ) {
+        if (!chatRoomUserRepository.existsByUserIdAndChatRoomId(user.id, chatRoom.id)) {
+            logger.error { "User ${user.id} is not in ChatRoom ${chatRoom.id}" }
+            throw EntityNotFoundException("User ${user.id} is not in ChatRoom ${chatRoom.id}")
+        }
+    }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
@@ -1,13 +1,16 @@
 package com.backgu.amaker.chat.service
 
-import com.backgu.amaker.chat.repository.ChatRoomRepository
-import com.backgu.amaker.chat.repository.ChatRoomUserRepository
+import com.backgu.amaker.chat.domain.Chat
+import com.backgu.amaker.chat.jpa.ChatEntity
+import com.backgu.amaker.chat.repository.ChatRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional(readOnly = true)
 class ChatService(
-    private val chatRoomRepository: ChatRoomRepository,
-    private val chatRoomUserRepository: ChatRoomUserRepository,
-)
+    private val chatRepository: ChatRepository,
+) {
+    @Transactional
+    fun save(chat: Chat): Chat = chatRepository.save(ChatEntity.of(chat)).toDomain()
+}

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
@@ -1,0 +1,57 @@
+package com.backgu.amaker.chat.service
+
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.chat.dto.ChatDto
+import com.backgu.amaker.chat.dto.GeneralChatCreateDto
+import com.backgu.amaker.fixture.ChatFixtureFacade
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.Test
+
+@DisplayName("ChatFacadeService 테스트")
+@Transactional
+@SpringBootTest
+class ChatFacadeServiceTest {
+    @Autowired
+    lateinit var chatFacadeService: ChatFacadeService
+
+    @Autowired
+    lateinit var fixture: ChatFixtureFacade
+
+    @BeforeEach
+    fun setUp() {
+        fixture.setUp()
+    }
+
+    @Test
+    @DisplayName("일반 채팅 생성 테스트")
+    fun createGeneralChat() {
+        // given
+        val userId = "tester"
+        fixture.user.createPersistedUser(userId)
+        val workspace = fixture.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixture.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = userId)
+        val chatRoom =
+            fixture.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+        fixture.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(userId))
+
+        val generalChatCreateDto =
+            GeneralChatCreateDto(
+                userId = userId,
+                content = "content",
+            )
+
+        // when
+        val chatDto: ChatDto =
+            chatFacadeService.createGeneralChat(generalChatCreateDto = generalChatCreateDto, chatRoomId = chatRoom.id)
+
+        // then
+        assertThat(chatDto.userId).isEqualTo(userId)
+        assertThat(chatDto.chatRoomId).isEqualTo(chatRoom.id)
+        assertThat(chatDto.content).isEqualTo(generalChatCreateDto.content)
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
@@ -1,11 +1,11 @@
 package com.backgu.amaker.chat.service
 
-import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.dto.ChatDto
 import com.backgu.amaker.chat.dto.GeneralChatCreateDto
 import com.backgu.amaker.fixture.ChatFixtureFacade
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -19,29 +19,32 @@ class ChatFacadeServiceTest {
     @Autowired
     lateinit var chatFacadeService: ChatFacadeService
 
-    @Autowired
-    lateinit var fixture: ChatFixtureFacade
+    companion object {
+        private lateinit var fixture: ChatFixtureFacade
+        private const val DEFAULT_USER_ID: String = "default-user"
 
-    @BeforeEach
-    fun setUp() {
-        fixture.setUp()
+        @JvmStatic
+        @BeforeAll
+        fun setUp(
+            @Autowired fixture: ChatFixtureFacade,
+        ) {
+            fixture.setUp()
+            this.fixture = fixture
+        }
     }
 
     @Test
     @DisplayName("일반 채팅 생성 테스트")
     fun createGeneralChat() {
         // given
-        val userId = "tester"
-        fixture.user.createPersistedUser(userId)
-        val workspace = fixture.workspace.createPersistedWorkspace(name = "워크스페이스1")
-        fixture.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = userId)
-        val chatRoom =
-            fixture.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
-        fixture.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(userId))
+        val chatRoom: ChatRoom =
+            fixture.setUp(
+                userId = DEFAULT_USER_ID,
+            )
 
         val generalChatCreateDto =
             GeneralChatCreateDto(
-                userId = userId,
+                userId = DEFAULT_USER_ID,
                 content = "content",
             )
 
@@ -50,7 +53,7 @@ class ChatFacadeServiceTest {
             chatFacadeService.createGeneralChat(generalChatCreateDto = generalChatCreateDto, chatRoomId = chatRoom.id)
 
         // then
-        assertThat(chatDto.userId).isEqualTo(userId)
+        assertThat(chatDto.userId).isEqualTo(DEFAULT_USER_ID)
         assertThat(chatDto.chatRoomId).isEqualTo(chatRoom.id)
         assertThat(chatDto.content).isEqualTo(generalChatCreateDto.content)
     }

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixtureFacade.kt
@@ -14,9 +14,14 @@ class ChatFixtureFacade(
     val workspaceUser: WorkspaceUserFixture,
     val user: UserFixture,
 ) {
-    fun setUp() {
-        val leader: User = user.createPersistedUser(name = "김리더", email = "leader@amaker.com")
-        val workspace: Workspace = workspace.createPersistedWorkspace(name = "테스트 워크스페이스")
+    fun setUp(
+        userId: String = "test-user-id",
+        name: String = "김리더",
+        email: String = "leader@amaker.com",
+        workspaceName: String = "테스트 워크스페이스",
+    ): ChatRoom {
+        val leader: User = user.createPersistedUser(id = userId, name = name, email = email)
+        val workspace: Workspace = workspace.createPersistedWorkspace(name = workspaceName)
         val members: List<User> = user.createPersistedUsers(10)
 
         val workspaceUsers: List<WorkspaceUser> =
@@ -26,15 +31,14 @@ class ChatFixtureFacade(
                 memberIds = members.map { it.id },
             )
 
-        val chatRooms: List<ChatRoom> =
-            chatRoom.testChatRoomSetUp(count = 10, workspace = workspace)
+        val chatRoom = chatRoom.testGroupChatRoomSetUp(workspace = workspace)
 
-        chatRooms.forEach { chatRoom ->
-            chatRoomUser.createPersistedChatRoomUser(
-                chatRoomId = chatRoom.id,
-                userIds = workspaceUsers.map { it.userId },
-            )
-        }
+        chatRoomUser.createPersistedChatRoomUser(
+            chatRoomId = chatRoom.id,
+            userIds = workspaceUsers.map { it.userId },
+        )
+
+        return chatRoom
     }
 
     fun deleteAll() {

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixtureFacade.kt
@@ -1,0 +1,47 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
+import com.backgu.amaker.workspace.domain.WorkspaceUser
+import org.springframework.stereotype.Component
+
+@Component
+class ChatFixtureFacade(
+    val chatRoom: ChatRoomFixture,
+    val chatRoomUser: ChatRoomUserFixture,
+    val workspace: WorkspaceFixture,
+    val workspaceUser: WorkspaceUserFixture,
+    val user: UserFixture,
+) {
+    fun setUp() {
+        val leader: User = user.createPersistedUser(name = "김리더", email = "leader@amaker.com")
+        val workspace: Workspace = workspace.createPersistedWorkspace(name = "테스트 워크스페이스")
+        val members: List<User> = user.createPersistedUsers(10)
+
+        val workspaceUsers: List<WorkspaceUser> =
+            workspaceUser.createPersistedWorkspaceUser(
+                workspaceId = workspace.id,
+                leaderId = leader.id,
+                memberIds = members.map { it.id },
+            )
+
+        val chatRooms: List<ChatRoom> =
+            chatRoom.testChatRoomSetUp(count = 10, workspace = workspace)
+
+        chatRooms.forEach { chatRoom ->
+            chatRoomUser.createPersistedChatRoomUser(
+                chatRoomId = chatRoom.id,
+                userIds = workspaceUsers.map { it.userId },
+            )
+        }
+    }
+
+    fun deleteAll() {
+        chatRoom.deleteAll()
+        chatRoomUser.deleteAll()
+        workspace.deleteAll()
+        workspaceUser.deleteAll()
+        user.deleteAll()
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
@@ -20,14 +20,8 @@ class ChatRoomFixture(
                 ChatRoomEntity(workspaceId = workspaceId, chatRoomType = chatRoomType),
             ).toDomain()
 
-    fun testChatRoomSetUp(
-        count: Int,
-        workspace: Workspace,
-        chatRoomType: ChatRoomType? = null,
-    ): List<ChatRoom> =
-        (1..count).map {
-            createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = chatRoomType ?: ChatRoomType.GROUP)
-        }
+    fun testGroupChatRoomSetUp(workspace: Workspace): ChatRoom =
+        createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
 
     fun deleteAll() {
         chatRoomRepository.deleteAll()

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixtureFacade.kt
@@ -1,6 +1,5 @@
 package com.backgu.amaker.fixture
 
-import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.domain.WorkspaceUser
@@ -26,15 +25,12 @@ class WorkspaceFixtureFacade(
                 memberIds = members.map { it.id },
             )
 
-        val chatRooms: List<ChatRoom> =
-            chatRoom.testChatRoomSetUp(count = 10, workspace = workspace)
+        val chatRoom = chatRoom.testGroupChatRoomSetUp(workspace = workspace)
 
-        chatRooms.forEach { chatRoom ->
-            chatRoomUser.createPersistedChatRoomUser(
-                chatRoomId = chatRoom.id,
-                userIds = workspaceUsers.map { it.userId },
-            )
-        }
+        chatRoomUser.createPersistedChatRoomUser(
+            chatRoomId = chatRoom.id,
+            userIds = workspaceUsers.map { it.userId },
+        )
     }
 
     fun deleteAll() {

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
@@ -1,6 +1,5 @@
 package com.backgu.amaker.workspace.service
 
-import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,4 +1,3 @@
-
 plugins {
     kotlin("jvm")
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/Chat.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/Chat.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.chat.domain
+
+import com.backgu.amaker.common.domain.BaseTime
+import java.time.LocalDateTime
+
+class Chat(
+    val id: Long = 0L,
+    val userId: String,
+    val chatRoomId: Long,
+    var content: String,
+    val chatType: ChatType,
+    createdAt: LocalDateTime = LocalDateTime.now(),
+    updatedAt: LocalDateTime = LocalDateTime.now(),
+) : BaseTime(createdAt, updatedAt)

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
@@ -9,4 +9,15 @@ class ChatRoom(
     val chatRoomType: ChatRoomType,
 ) : BaseTime() {
     fun addUser(user: User): ChatRoomUser = ChatRoomUser(userId = user.id, chatRoomId = id)
+
+    fun createGeneralChat(
+        user: User,
+        chatRoom: ChatRoom,
+        content: String,
+    ) = Chat(
+        userId = user.id,
+        chatRoomId = chatRoom.id,
+        content = content,
+        chatType = ChatType.GENERAL,
+    )
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatType.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatType.kt
@@ -1,0 +1,8 @@
+package com.backgu.amaker.chat.domain
+
+enum class ChatType {
+    GENERAL,
+    TASK,
+    REPLY,
+    REACTION,
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatEntity.kt
@@ -1,0 +1,49 @@
+package com.backgu.amaker.chat.jpa
+
+import com.backgu.amaker.chat.domain.Chat
+import com.backgu.amaker.chat.domain.ChatType
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "Chat")
+@Table(name = "chat")
+class ChatEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    val chatRoomId: Long,
+    @Column(nullable = false)
+    val userId: String,
+    @Column(nullable = false)
+    var content: String,
+    @Enumerated(EnumType.STRING)
+    val chatType: ChatType,
+) : BaseTimeEntity() {
+    fun toDomain(): Chat =
+        Chat(
+            chatRoomId = chatRoomId,
+            userId = userId,
+            content = content,
+            chatType = chatType,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    companion object {
+        fun of(chat: Chat) =
+            ChatEntity(
+                chatRoomId = chat.chatRoomId,
+                userId = chat.userId,
+                content = chat.content,
+                chatType = chat.chatType,
+            )
+    }
+}

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
@@ -23,4 +23,21 @@ class ChatRoomTest {
         assertThat(chatRoomUser.userId).isEqualTo("user1")
         assertThat(chatRoomUser.chatRoomId).isEqualTo(chatRoom.id)
     }
+
+    @Test
+    @DisplayName("채팅방에 일반 채팅을 생성할 수 있다")
+    fun createGeneralChat() {
+        // given
+        val user =
+            User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
+        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.GROUP)
+        val content = "안녕하세요"
+
+        // when
+        val chat: Chat = chatRoom.createGeneralChat(user = user, chatRoom = chatRoom, content = content)
+
+        // then
+        assertThat(chat.chatType).isEqualTo(ChatType.GENERAL)
+        assertThat(chat.content).isEqualTo(content)
+    }
 }


### PR DESCRIPTION
# Why
Stomp를 활용하여 채팅을 전송하고 채팅을 DB에 저장한다

# How
단순하게 userId와 content를 `Payload`에 담아서 보내고 있다
이때 userId에 대한 정보를 이렇게 보내는게 맞는지에 대한 의문이 든다

하지만 jwt를 활용하여 매번 통신마다 interceptor에서 `authentication` 정보를
주입시켜주는 것도 맞는지 모르겠다

그래서 아직 개발 초기 단계인 만큼 userId를 단순하게 보내게 설계하였다

# Result
```kotlin
class Chat(
    val id: Long = 0L,
    val userId: String,
    val chatRoomId: Long,
    var content: String,
    val chatType: ChatType,
    createdAt: LocalDateTime = LocalDateTime.now(),
    updatedAt: LocalDateTime = LocalDateTime.now(),
) : BaseTime(createdAt, updatedAt)
```
```kotlin
class ChatRoom(
    val id: Long = 0L,
    val workspaceId: Long,
    val chatRoomType: ChatRoomType,
) : BaseTime() {
    fun addUser(user: User): ChatRoomUser = ChatRoomUser(userId = user.id, chatRoomId = id)

    fun createGeneralChat(
        user: User,
        chatRoom: ChatRoom,
        content: String,
    ) = Chat(
        userId = user.id,
        chatRoomId = chatRoom.id,
        content = content,
        chatType = ChatType.GENERAL,
    )
}
```
채팅 도메인 생성시에 채팅방이 채팅을 생성하는 책임이 있다고 생각을 하여
채팅방이 채팅을 생성한다

# Link
BG-179