### PR TITLE
[BG-160]: 커스텀 Exception 적용 (3h / 3h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/auth/service/AuthService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/auth/service/AuthService.kt
@@ -5,8 +5,9 @@ import com.backgu.amaker.auth.dto.oauth.google.GoogleOAuth2AccessTokenDto
 import com.backgu.amaker.auth.dto.oauth.google.GoogleUserInfoDto
 import com.backgu.amaker.auth.infra.GoogleApiClient
 import com.backgu.amaker.auth.infra.GoogleOAuthClient
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import org.springframework.stereotype.Service
-import java.lang.IllegalArgumentException
 
 @Service
 class AuthService(
@@ -22,11 +23,11 @@ class AuthService(
                 authConfig.grantType,
                 authConfig.clientSecret,
                 authConfig.clientId,
-            ) ?: throw IllegalArgumentException("Failed to get access token")
+            ) ?: throw BusinessException(StatusCode.OAUTH_SOCIAL_LOGIN_FAILED)
 
         val userInfo: GoogleUserInfoDto =
             googleApiClient.getUserInfo(accessTokenDto.getBearerToken())
-                ?: throw IllegalArgumentException("Failed to get user information")
+                ?: throw BusinessException(StatusCode.OAUTH_SOCIAL_LOGIN_FAILED)
 
         return userInfo
     }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -4,9 +4,10 @@ import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomType
 import com.backgu.amaker.chat.jpa.ChatRoomEntity
 import com.backgu.amaker.chat.repository.ChatRoomRepository
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.workspace.domain.Workspace
 import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,13 +23,13 @@ class ChatRoomService(
 
     fun getGroupChatRoomByWorkspace(workspace: Workspace): ChatRoom =
         chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspace.id, ChatRoomType.GROUP)?.toDomain()
-            // TODO : 공통 에러처리 추후에 해줘야함
             ?: run {
+                // TODO : 로깅 전략 세워야 함
                 logger.error { "Group ChatRoom not found in Workspace ${workspace.id}" }
-                throw EntityNotFoundException("Group ChatRoom not found in Workspace ${workspace.id}")
+                throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
             }
 
     fun findGroupChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
         chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.GROUP)?.toDomain()
-            ?: throw EntityNotFoundException("Group ChatRoom not found in Workspace $workspaceId")
+            ?: throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
 }

--- a/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiError.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiError.kt
@@ -1,17 +1,34 @@
 package com.backgu.amaker.common.dto.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 class ApiError<T>(
-    timestamp: String,
-    path: String,
-    status: Int,
-    data: T,
-    @Schema(description = "에러 reason Phrase", example = "Bad Request")
-    val error: String,
-) : ApiResult<T>(
-        timestamp = timestamp,
-        path = path,
-        status = status,
-        data = data,
+    override val timestamp: String,
+    override val status: String,
+    override val path: String,
+    override val data: ErrorResponse<T>,
+) : ApiResult<ApiError.ErrorResponse<T>> {
+    data class ErrorResponse<U>(
+        @Schema(description = "에러 미시지", example = "워크스페이스를 찾을 수 없습니다.")
+        val message: String,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        val detail: U?,
     )
+
+    companion object {
+        fun <U> of(
+            timestamp: String,
+            status: String,
+            path: String,
+            message: String,
+            data: U?,
+        ): ApiError<U> =
+            ApiError(
+                timestamp = timestamp,
+                status = status,
+                path = path,
+                data = ErrorResponse(message, data),
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiResult.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiResult.kt
@@ -2,12 +2,14 @@ package com.backgu.amaker.common.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 
-open class ApiResult<T>(
-    @Schema(description = "KST 응답 타임스탬프", example = "2024-07-02T19:56:05.624+09:00")
-    val timestamp: String,
-    @Schema(description = "응답 status code", example = "200")
-    val status: Int,
-    @Schema(description = "요청 URL", example = "/api/v1/test")
-    val path: String,
-    val data: T,
-)
+interface ApiResult<T> {
+    @get:Schema(description = "KST 응답 타임스탬프", example = "2024-07-02T19:56:05.624+09:00")
+    val timestamp: String
+
+    @get:Schema(description = "응답 status code", example = "2000")
+    val status: String
+
+    @get:Schema(description = "요청 URL", example = "/api/v1/test")
+    val path: String
+    val data: T
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiSuccess.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/dto/response/ApiSuccess.kt
@@ -1,0 +1,8 @@
+package com.backgu.amaker.common.dto.response
+
+class ApiSuccess<T>(
+    override val timestamp: String,
+    override val status: String,
+    override val path: String,
+    override val data: T,
+) : ApiResult<T>

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/BusinessException.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/BusinessException.kt
@@ -1,0 +1,12 @@
+package com.backgu.amaker.common.exception
+
+import org.springframework.http.HttpStatus
+import kotlin.RuntimeException
+
+class BusinessException(
+    val statusCode: StatusCode,
+    val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    override val message: String = statusCode.message,
+) : RuntimeException(message) {
+    constructor(statusCode: StatusCode, message: String) : this(statusCode, HttpStatus.BAD_REQUEST, message)
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/GlobalExceptionHandler.kt
@@ -3,7 +3,7 @@ package com.backgu.amaker.common.exception
 import com.backgu.amaker.common.dto.response.ApiError
 import com.backgu.amaker.common.infra.ApiHandler
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 
@@ -13,11 +13,17 @@ class GlobalExceptionHandler(
 ) {
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ApiError<Map<String, String>>> {
-        val errorMap: Map<String, String> =
-            e.bindingResult.fieldErrors.associate { error ->
+        val errorMap: Map<String, String>? =
+            e.bindingResult?.fieldErrors?.associate { error ->
                 error.field to (error.defaultMessage ?: "Invalid value")
             }
 
-        return ResponseEntity.badRequest().body(apiHandler.onFailure(errorMap))
+        return ResponseEntity
+            .badRequest()
+            .body(apiHandler.onFailure(StatusCode.INVALID_INPUT_VALUE, errorMap))
     }
+
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(e: BusinessException): ResponseEntity<ApiError<Unit>> =
+        ResponseEntity.status(e.httpStatus).body(apiHandler.onFailure(e.statusCode))
 }

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
@@ -1,0 +1,27 @@
+package com.backgu.amaker.common.exception
+
+enum class StatusCode(
+    val code: String,
+    val message: String,
+) {
+    // OK
+    SUCCESS("2000", "성공"),
+
+    // general
+    INVALID_INPUT_VALUE("4000", "잘못된 입력입니다."),
+
+    // user
+    USER_NOT_FOUND("4000", "사용자를 찾을 수 없습니다."),
+
+    // auth
+    OAUTH_SOCIAL_LOGIN_FAILED("4000", "로그인에 실패했습니다."),
+
+    // chat
+    CHAT_ROOM_NOT_FOUND("4000", "채팅방이 존재하지 않습니다."),
+
+    // workspace
+    WORKSPACE_NOT_FOUND("4000", "워크스페이스를 찾을 수 없습니다."),
+
+    // workspaceUser
+    WORKSPACE_UNREACHABLE("4000", "워크스페이스에 접근할 수 없습니다."),
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/infra/ApiHandler.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/infra/ApiHandler.kt
@@ -2,10 +2,11 @@ package com.backgu.amaker.common.infra
 
 import com.backgu.amaker.common.dto.response.ApiError
 import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.common.dto.response.ApiSuccess
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.common.service.ClockHolder
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 
 @Component
@@ -16,24 +17,24 @@ class ApiHandler(
 ) {
     fun <T> onSuccess(
         data: T,
-        status: HttpStatus = HttpStatus.OK,
+        code: StatusCode = StatusCode.SUCCESS,
     ): ApiResult<T> =
-        ApiResult(
+        ApiSuccess(
             timestamp = clockHolder.now(),
             path = request.requestURI,
-            status = status.value(),
+            status = code.code,
             data = data,
         )
 
     fun <T> onFailure(
-        error: T,
-        status: HttpStatus = HttpStatus.BAD_REQUEST,
+        statusCode: StatusCode,
+        data: T? = null,
     ): ApiError<T> =
-        ApiError<T>(
+        ApiError.of(
             timestamp = clockHolder.now(),
+            status = statusCode.code,
             path = request.requestURI,
-            status = status.value(),
-            data = error,
-            error = status.reasonPhrase,
+            message = statusCode.message,
+            data = data,
         )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/security/JwtAuthenticationProvider.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/JwtAuthenticationProvider.kt
@@ -20,8 +20,7 @@ class JwtAuthenticationProvider(
         )
 
     private fun processOAuthAuthentication(email: String): Authentication {
-        // TODO exception handling
-        val user: User = userService.getByEmail(email) ?: throw IllegalArgumentException("User not found")
+        val user: User = userService.getByEmail(email)
         val authenticated: JwtAuthenticationToken =
             JwtAuthenticationToken(
                 JwtAuthentication(user.id, user.name),

--- a/api/src/main/kotlin/com/backgu/amaker/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/service/UserService.kt
@@ -1,5 +1,7 @@
 package com.backgu.amaker.user.service
 
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.jpa.UserEntity
 import com.backgu.amaker.user.repository.UserRepository
@@ -21,17 +23,17 @@ class UserService(
         return savedUser.toDomain()
     }
 
-    // TODO exception handling
     fun getById(id: String): User =
         userRepository.findByIdOrNull(id)?.toDomain() ?: run {
+            // TODO 로깅 전략 세우기
             logger.error { "User not found : $id" }
-            throw IllegalArgumentException("User not found : $id")
+            throw BusinessException(StatusCode.USER_NOT_FOUND)
         }
 
-    fun getByEmail(email: String): User {
-        // TODO exception handling
-        return userRepository.findByEmail(email)?.toDomain() ?: throw IllegalArgumentException("User not found")
-    }
+    fun getByEmail(email: String): User =
+        userRepository.findByEmail(email)?.toDomain() ?: throw BusinessException(
+            StatusCode.USER_NOT_FOUND,
+        )
 
     @Transactional
     fun saveOrGetUser(user: User): User = userRepository.findByEmail(user.email)?.toDomain() ?: save(user)

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceUserDto.kt
@@ -1,21 +1,22 @@
 package com.backgu.amaker.workspace.dto
 
 import com.backgu.amaker.workspace.domain.WorkspaceUser
-import com.backgu.amaker.workspace.domain.WorkspaceUserStatus
+import io.swagger.v3.oas.annotations.media.Schema
 
 class WorkspaceUserDto(
-    val userId: String,
+    @Schema(description = "워크스페이스 ID", example = "231")
     val workspaceId: Long,
+    @Schema(description = "워크스페이스 권한", example = "Leader")
     val workspaceRole: String,
-    val status: WorkspaceUserStatus,
+    @Schema(description = "워크스페이스 상태", example = "ACTIVE")
+    val status: String,
 ) {
     companion object {
         fun of(workspaceUser: WorkspaceUser): WorkspaceUserDto =
             WorkspaceUserDto(
-                userId = workspaceUser.userId,
                 workspaceId = workspaceUser.workspaceId,
                 workspaceRole = workspaceUser.workspaceRole.value,
-                status = workspaceUser.status,
+                status = workspaceUser.status.value,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceService.kt
@@ -1,11 +1,12 @@
 package com.backgu.amaker.workspace.service
 
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.jpa.WorkspaceEntity
 import com.backgu.amaker.workspace.repository.WorkspaceRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -26,7 +27,7 @@ class WorkspaceService(
     fun getById(id: Long): Workspace =
         workspaceRepository.findByIdOrNull(id)?.toDomain() ?: run {
             logger.error { "Workspace not found : $id" }
-            throw EntityNotFoundException("Workspace not found : $id")
+            throw BusinessException(StatusCode.WORKSPACE_NOT_FOUND)
         }
 
     fun getWorkspaceByIds(workspaceIds: List<Long>): List<Workspace> =
@@ -37,13 +38,13 @@ class WorkspaceService(
     fun getDefaultWorkspaceByUserId(user: User): Workspace =
         workspaceRepository.getDefaultWorkspaceByUserId(user.id)?.toDomain() ?: run {
             logger.error { "Default workspace not found : ${user.id}" }
-            throw EntityNotFoundException("Default workspace not found : ${user.id}")
+            throw BusinessException(StatusCode.WORKSPACE_NOT_FOUND)
         }
 
     fun getWorkspaceById(workspaceId: Long): Workspace =
-        // TODO : 공통 에러처리 추후에 해줘야함
+        // TODO : 로깅
         workspaceRepository.findByIdOrNull(workspaceId)?.toDomain() ?: run {
             logger.error { "Workspace not found : $workspaceId" }
-            throw EntityNotFoundException("Workspace not found : $workspaceId")
+            throw BusinessException(StatusCode.WORKSPACE_NOT_FOUND)
         }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
@@ -1,12 +1,13 @@
 package com.backgu.amaker.workspace.service
 
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.workspace.domain.Workspace
 import com.backgu.amaker.workspace.domain.WorkspaceUser
 import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
-import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -28,7 +29,7 @@ class WorkspaceUserService(
     ) {
         if (!workspaceUserRepository.existsByUserIdAndWorkspaceId(user.id, workspace.id)) {
             logger.error { "User ${user.id} is not in Workspace ${workspace.id}" }
-            throw EntityNotFoundException("User ${user.id} is not in Workspace ${workspace.id}")
+            throw BusinessException(StatusCode.WORKSPACE_UNREACHABLE)
         }
     }
 
@@ -40,5 +41,5 @@ class WorkspaceUserService(
         workspaceUserRepository
             .findByUserIdAndWorkspaceId(workspaceId = workspace.id, userId = user.id)
             ?.toDomain()
-            ?: throw IllegalArgumentException("User is not a member of the workspace")
+            ?: throw BusinessException(StatusCode.WORKSPACE_UNREACHABLE)
 }

--- a/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/user/service/UserServiceTest.kt
@@ -1,5 +1,7 @@
 package com.backgu.amaker.user.service
 
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.common.service.IdPublisher
 import com.backgu.amaker.fixture.UserFixture
 import com.backgu.amaker.user.domain.User
@@ -62,8 +64,10 @@ class UserServiceTest {
     fun getNoEmailUserTest() {
         // given & when & then
         assertThatThrownBy { userService.getByEmail("no@gmail.com") }
-            .isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessage("User not found")
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessage("사용자를 찾을 수 없습니다.")
+            .extracting("statusCode")
+            .isEqualTo(StatusCode.USER_NOT_FOUND)
     }
 
     @Test

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -2,13 +2,14 @@ package com.backgu.amaker.workspace.service
 
 import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.fixture.WorkspaceFixture.Companion.createWorkspaceRequest
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.workspace.domain.WorkspaceRole
 import com.backgu.amaker.workspace.domain.WorkspaceUser
 import com.backgu.amaker.workspace.domain.WorkspaceUserStatus
-import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -107,8 +108,10 @@ class WorkspaceFacadeServiceTest {
 
         // when & then
         assertThatThrownBy { workspaceFacadeService.getDefaultWorkspace(userId) }
-            .isInstanceOf(EntityNotFoundException::class.java)
-            .hasMessage("Default workspace not found : $userId")
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessage("워크스페이스를 찾을 수 없습니다.")
+            .extracting("statusCode")
+            .isEqualTo(StatusCode.WORKSPACE_NOT_FOUND)
     }
 
     @Test
@@ -181,7 +184,9 @@ class WorkspaceFacadeServiceTest {
 
         // when & then
         assertThatThrownBy { workspaceFacadeService.activateWorkspaceUser(memberId, 0L) }
-            .isInstanceOf(EntityNotFoundException::class.java)
-            .hasMessage("Workspace not found : 0")
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessage("워크스페이스를 찾을 수 없습니다.")
+            .extracting("statusCode")
+            .isEqualTo(StatusCode.WORKSPACE_NOT_FOUND)
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceServiceTest.kt
@@ -1,9 +1,10 @@
 package com.backgu.amaker.workspace.service
 
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.workspace.domain.Workspace
-import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
@@ -80,8 +81,10 @@ class WorkspaceServiceTest {
 
         // when & then
         assertThatThrownBy { workspaceService.getDefaultWorkspaceByUserId(user) }
-            .isInstanceOf(EntityNotFoundException::class.java)
-            .hasMessage("Default workspace not found : tester")
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessage("워크스페이스를 찾을 수 없습니다.")
+            .extracting("statusCode")
+            .isEqualTo(StatusCode.WORKSPACE_NOT_FOUND)
     }
 
     companion object {

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserServiceTest.kt
@@ -1,9 +1,10 @@
 package com.backgu.amaker.workspace.service
 
 import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.fixture.WorkspaceFixtureFacade
 import com.backgu.amaker.user.domain.User
-import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -57,7 +58,9 @@ class WorkspaceUserServiceTest {
 
         // when & then
         assertThatThrownBy { workspaceUserService.validUserInWorkspace(user, workspace) }
-            .isInstanceOf(EntityNotFoundException::class.java)
-            .hasMessage("User ${user.id} is not in Workspace ${workspace.id}")
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessage("워크스페이스에 접근할 수 없습니다.")
+            .extracting("statusCode")
+            .isEqualTo(StatusCode.WORKSPACE_UNREACHABLE)
     }
 }


### PR DESCRIPTION
# Why

```kotlin
class BusinessException(
    val statusCode: StatusCode,
    val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
    override val message: String = statusCode.message,
) : RuntimeException(message) {
    constructor(statusCode: StatusCode, message: String) : this(statusCode, HttpStatus.BAD_REQUEST, message)
}

enum class StatusCode(
    val code: String,
    val message: String,
) {
    // OK
    SUCCESS("2000", "성공"),

    // general
    INVALID_INPUT_VALUE("4000", "잘못된 입력입니다."),

    // user
    USER_NOT_FOUND("4000", "사용자를 찾을 수 없습니다."),

    // auth
    OAUTH_SOCIAL_LOGIN_FAILED("4000", "로그인에 실패했습니다."),

    // chat
    CHAT_ROOM_NOT_FOUND("4000", "채팅방이 존재하지 않습니다."),

    // workspace
    WORKSPACE_NOT_FOUND("4000", "워크스페이스를 찾을 수 없습니다."),

    // workspaceUser
    WORKSPACE_UNREACHABLE("4000", "워크스페이스에 접근할 수 없습니다."),
}
```
* 해당 예외로 포맷 적용

# Link
BG-160
