### PR TITLE
[BG-162]: CORS 대응하기 (0.2h / 0.5h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/security/config/CorsConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/config/CorsConfig.kt
@@ -1,0 +1,13 @@
+package com.backgu.amaker.security.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "cors")
+class CorsConfig(
+    var allowedMethods: List<String> = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS"),
+    var allowedHeaders: List<String> = listOf("*"),
+) {
+    lateinit var allowedOrigins: List<String>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
@@ -11,6 +11,8 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.ExceptionTranslationFilter
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
@@ -18,6 +20,7 @@ class SecurityConfig(
     private val jwtAuthenticationTokenFilter: JwtAuthenticationTokenFilter,
     private val authAccessDeniedHandler: AuthAccessDeniedHandler,
     private val authEntryPoint: AuthEntryPoint,
+    private val corsConfig: CorsConfig,
 ) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -51,5 +54,17 @@ class SecurityConfig(
             }
 
         return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): UrlBasedCorsConfigurationSource {
+        val source = UrlBasedCorsConfigurationSource()
+        val config = CorsConfiguration()
+        config.allowedOrigins = corsConfig.allowedOrigins
+        config.allowedMethods = corsConfig.allowedMethods
+        config.allowedHeaders = corsConfig.allowedHeaders
+        config.allowCredentials = true
+        source.registerCorsConfiguration("/**", config)
+        return source
     }
 }

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -33,3 +33,16 @@ jwt:
 
 swagger:
   url: ${SWAGGER_URL}
+
+cors:
+  allowed-origins:
+    - http://localhost:3000
+    - http://127.0.0.1:3000
+  allowed-headers:
+    - GET
+    - HEAD
+    - POST
+    - PUT
+    - DELETE
+    - PATCH
+    - OPTIONS

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -31,3 +31,15 @@ jwt:
 
 swagger:
   url: http://localhost:8080
+
+cors:
+  allowed-origins:
+    - "*"
+  allowed-headers:
+    - GET
+    - HEAD
+    - POST
+    - PUT
+    - DELETE
+    - PATCH
+    - OPTIONS


### PR DESCRIPTION
# Why

클라이언트에서 채팅 테스트를 하기 위해 cors 대응이 필요하다

# How

```yaml
cors:
  allowed-origins:
    - http://localhost:3000
    - http://127.0.0.1:3000
  allowed-headers:
    - GET
    - HEAD
    - POST
    - PUT
    - DELETE
    - PATCH
    - OPTIONS
```

```kotlin
  @Bean
  fun corsConfigurationSource(): UrlBasedCorsConfigurationSource {
      val source = UrlBasedCorsConfigurationSource()
      val config = CorsConfiguration()
      config.allowedOrigins = corsConfig.allowedOrigins
      config.allowedMethods = corsConfig.allowedMethods
      config.allowedHeaders = corsConfig.allowedHeaders
      config.allowCredentials = true
      source.registerCorsConfiguration("/**", config)
      return source
  }
```

# Link

BG-162