### PR TITLE
[BG-211]: 프론트에서 접속가능하도록 인증 처리 수정 (1h / 2h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiController.kt
@@ -8,6 +8,7 @@ import com.backgu.amaker.common.dto.response.ApiResult
 import com.backgu.amaker.common.infra.ApiHandler
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -23,16 +24,13 @@ class AuthApiController(
     override fun googleAuth(): ResponseEntity<ApiResult<OAuthUrlResponse>> =
         ResponseEntity.ok().body(
             apiHandler.onSuccess(
-                OAuthUrlResponse(authConfig.oauthUrl),
+                OAuthUrlResponse(authConfig.oauthUrl()),
             ),
         )
 
-    @GetMapping("/code/google")
+    @PostMapping("/code/google")
     override fun login(
         @RequestParam(name = "code") authorizationCode: String,
-        @RequestParam(name = "scope", required = false) scope: String,
-        @RequestParam(name = "authuser", required = false) authUser: String,
-        @RequestParam(name = "prompt", required = false) prompt: String,
     ): ResponseEntity<ApiResult<JwtTokenResponse>> =
         ResponseEntity.ok().body(
             apiHandler.onSuccess(

--- a/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/auth/controller/AuthApiSwagger.kt
@@ -31,10 +31,5 @@ interface AuthApiSwagger {
             ),
         ],
     )
-    fun login(
-        authorizationCode: String,
-        scope: String,
-        authUser: String,
-        prompt: String,
-    ): ResponseEntity<ApiResult<JwtTokenResponse>>
+    fun login(authorizationCode: String): ResponseEntity<ApiResult<JwtTokenResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
@@ -25,6 +25,9 @@ class SecurityConfig(
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .cors {
+                it.configurationSource(corsConfigurationSource())
+            }
             .csrf {
                 it.disable()
             }.sessionManagement {

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ oauth:
   google:
     client-id: ${CLIENT_ID}
     client-secret: ${CLIENT_SECRET}
-    redirect-uri: "http://localhost:8080/api/v1/auth/code/google"
+    redirect-uri: "http://localhost:3000/login"
     base-url: "https://accounts.google.com/o/oauth2/auth"
     oauth-url: "https://oauth2.googleapis.com"
     api-url: "https://www.googleapis.com"


### PR DESCRIPTION
PR 제목
[BG-22]: PR 제목 (실제소요시간h / 스토리포인트h)

# Why

* `cors` 세팅을 넣어주지 않은 것 다시 넣어줌
* oauth 인증을 클라이언트에서 직접 호출하도록 수정

# Link
BG-211