### PR TITLE
[BG-175]: 초대 링크를 이메일로 전송하는 API를 구현한다 (4h / 4h)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     implementation("com.auth0:java-jwt:3.18.3")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")

--- a/api/src/main/kotlin/com/backgu/amaker/AMakerApiApplication.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/AMakerApiApplication.kt
@@ -3,7 +3,9 @@ package com.backgu.amaker
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 
+@EnableAsync
 @SpringBootApplication
 @EntityScan(basePackages = ["com.backgu.amaker"])
 class AMakerApiApplication

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/GlobalExceptionHandler.kt
@@ -11,6 +11,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class GlobalExceptionHandler(
     private val apiHandler: ApiHandler,
 ) {
+    @ExceptionHandler(RuntimeException::class)
+    fun handleRuntimeException(e: RuntimeException): ResponseEntity<ApiError<Unit>> {
+        e.printStackTrace()
+        return ResponseEntity
+            .internalServerError()
+            .body(apiHandler.onFailure(StatusCode.INTERNAL_SERVER_ERROR))
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ApiError<Map<String, String>>> {
         val errorMap: Map<String, String>? =

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
@@ -21,6 +21,7 @@ enum class StatusCode(
 
     // workspace
     WORKSPACE_NOT_FOUND("4000", "워크스페이스를 찾을 수 없습니다."),
+    INVALID_WORKSPACE_CREATE("4000", "잘못된 워크스페이스 생성 요청입니다."),
 
     // workspaceUser
     WORKSPACE_UNREACHABLE("4000", "워크스페이스에 접근할 수 없습니다."),

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
@@ -7,6 +7,9 @@ enum class StatusCode(
     // OK
     SUCCESS("2000", "성공"),
 
+    // INTERNAL_SERVER_ERROR
+    INTERNAL_SERVER_ERROR("5000", "죄송합니다. 다음에 다시 시도해주세요."),
+
     // general
     INVALID_INPUT_VALUE("4000", "잘못된 입력입니다."),
 

--- a/api/src/main/kotlin/com/backgu/amaker/common/validator/EmailListValidator.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/validator/EmailListValidator.kt
@@ -1,0 +1,26 @@
+package com.backgu.amaker.common.validator
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Validation
+import jakarta.validation.constraints.Email
+
+class EmailListValidator : ConstraintValidator<ValidEmailList, Set<String>> {
+    private val validator = Validation.buildDefaultValidatorFactory().validator
+
+    override fun isValid(
+        emails: Set<String>?,
+        context: ConstraintValidatorContext,
+    ): Boolean {
+        if (emails == null) return true
+
+        return emails.all { email ->
+            validator.validate(EmailHolder(email)).isEmpty()
+        }
+    }
+
+    private class EmailHolder(
+        @field:Email
+        val email: String,
+    )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/common/validator/ValidEmailList.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/validator/ValidEmailList.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.common.validator
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [EmailListValidator::class])
+annotation class ValidEmailList(
+    val message: String = "Invalid email address in the list",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+)

--- a/api/src/main/kotlin/com/backgu/amaker/mail/config/MailClientConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/config/MailClientConfig.kt
@@ -1,0 +1,25 @@
+package com.backgu.amaker.mail.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class MailClientConfig {
+    @Value("\${spring.mail.host}")
+    lateinit var host: String
+
+    @Value("\${spring.mail.port}")
+    lateinit var port: String
+
+    @Value("\${spring.mail.username}")
+    lateinit var username: String
+
+    @Value("\${spring.mail.password}")
+    lateinit var password: String
+
+    @Value("\${spring.mail.properties.mail.smtp.auth}")
+    lateinit var auth: String
+
+    @Value("\${spring.mail.properties.mail.smtp.starttls.enable}")
+    lateinit var starttls: String
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/config/MailConstantsConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/config/MailConstantsConfig.kt
@@ -1,0 +1,30 @@
+package com.backgu.amaker.mail.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.JavaMailSenderImpl
+import java.util.Properties
+
+@Configuration
+class MailConstantsConfig(
+    private val mailClientConfig: MailClientConfig,
+) {
+    @Bean
+    fun javaMailSender(): JavaMailSender {
+        val javaMailSender = JavaMailSenderImpl()
+
+        javaMailSender.host = mailClientConfig.host
+        javaMailSender.port = mailClientConfig.port.toInt()
+        javaMailSender.username = mailClientConfig.username
+        javaMailSender.password = mailClientConfig.password
+
+        val props: Properties = javaMailSender.javaMailProperties
+        props["mail.smtp.starttls.enable"] = mailClientConfig.starttls.toBoolean()
+        props["mail.transport.protocol"] = "smtp"
+        props["mail.smtp.auth"] = mailClientConfig.auth.toBoolean()
+        props["mail.smtp.starttls.enable"] = mailClientConfig.starttls.toBoolean()
+
+        return javaMailSender
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/constants/EmailConstants.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/constants/EmailConstants.kt
@@ -1,0 +1,9 @@
+package com.backgu.amaker.mail.constants
+
+enum class EmailConstants(
+    val templateName: String,
+    val title: String,
+) {
+    WORKSPACE_INVITED("workspace-invite", "%s님은 워크스페이스에 초대되었습니다."),
+    WORKSPACE_JOINED("workspace-join", "%s님은 워크스페이스에 가입되었습니다."),
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/event/EmailEvent.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/event/EmailEvent.kt
@@ -1,0 +1,12 @@
+package com.backgu.amaker.mail.event
+
+import com.backgu.amaker.mail.constants.EmailConstants
+
+interface EmailEvent {
+    val email: String
+    val emailConstants: EmailConstants
+
+    fun emailModel(): Map<String, Any>
+
+    fun title(): String
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/infra/HtmlEmailSender.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/infra/HtmlEmailSender.kt
@@ -1,0 +1,29 @@
+package com.backgu.amaker.mail.infra
+
+import com.backgu.amaker.mail.config.MailClientConfig
+import com.backgu.amaker.mail.service.EmailSender
+import jakarta.mail.internet.MimeMessage
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.stereotype.Component
+
+@Component
+class HtmlEmailSender(
+    val mailSender: JavaMailSender,
+    val mailClientConfig: MailClientConfig,
+) : EmailSender {
+    override fun sendEmail(
+        emailAddress: String,
+        title: String,
+        body: String,
+    ) {
+        val msg: MimeMessage = mailSender.createMimeMessage()
+        val helper = MimeMessageHelper(msg, true, "UTF-8")
+
+        helper.setTo(emailAddress)
+        helper.setSubject(title)
+        helper.setText(body, true)
+
+        mailSender.send(msg)
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/infra/HtmlEmailSender.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/infra/HtmlEmailSender.kt
@@ -1,29 +1,35 @@
 package com.backgu.amaker.mail.infra
 
-import com.backgu.amaker.mail.config.MailClientConfig
 import com.backgu.amaker.mail.service.EmailSender
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.mail.internet.MimeMessage
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Component
 
+private val logger = KotlinLogging.logger {}
+
 @Component
 class HtmlEmailSender(
     val mailSender: JavaMailSender,
-    val mailClientConfig: MailClientConfig,
 ) : EmailSender {
     override fun sendEmail(
         emailAddress: String,
         title: String,
         body: String,
     ) {
-        val msg: MimeMessage = mailSender.createMimeMessage()
-        val helper = MimeMessageHelper(msg, true, "UTF-8")
+        try {
+            val msg: MimeMessage = mailSender.createMimeMessage()
+            val helper = MimeMessageHelper(msg, true, "UTF-8")
 
-        helper.setTo(emailAddress)
-        helper.setSubject(title)
-        helper.setText(body, true)
+            helper.setTo(emailAddress)
+            helper.setSubject(title)
+            helper.setText(body, true)
 
-        mailSender.send(msg)
+            mailSender.send(msg)
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to send email to $emailAddress with title $title and body $body" }
+            throw RuntimeException("Failed to send email to $emailAddress with title $title and body $body")
+        }
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/mail/infra/ThymeleafEmailTemplateBuilder.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/infra/ThymeleafEmailTemplateBuilder.kt
@@ -1,9 +1,12 @@
 package com.backgu.amaker.mail.infra
 
 import com.backgu.amaker.mail.service.EmailTemplateBuilder
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
+
+private val logger = KotlinLogging.logger {}
 
 @Component
 class ThymeleafEmailTemplateBuilder(
@@ -13,8 +16,13 @@ class ThymeleafEmailTemplateBuilder(
         templateName: String,
         model: Map<String, Any>,
     ): String {
-        val context = Context()
-        context.setVariables(model)
-        return templateEngine.process(templateName, context)
+        try {
+            val context = Context()
+            context.setVariables(model)
+            return templateEngine.process(templateName, context)
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to Build email of $templateName" }
+            throw RuntimeException("Failed to Build email of $templateName")
+        }
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/mail/infra/ThymeleafEmailTemplateBuilder.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/infra/ThymeleafEmailTemplateBuilder.kt
@@ -1,0 +1,20 @@
+package com.backgu.amaker.mail.infra
+
+import com.backgu.amaker.mail.service.EmailTemplateBuilder
+import org.springframework.stereotype.Component
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
+
+@Component
+class ThymeleafEmailTemplateBuilder(
+    private val templateEngine: TemplateEngine,
+) : EmailTemplateBuilder {
+    override fun buildEmailContent(
+        templateName: String,
+        model: Map<String, Any>,
+    ): String {
+        val context = Context()
+        context.setVariables(model)
+        return templateEngine.process(templateName, context)
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailEventService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailEventService.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.mail.service
+
+import com.backgu.amaker.mail.event.EmailEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class EmailEventService(
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    fun publishEmailEvent(emailEvent: EmailEvent) {
+        eventPublisher.publishEvent(emailEvent)
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailSender.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailSender.kt
@@ -1,0 +1,9 @@
+package com.backgu.amaker.mail.service
+
+interface EmailSender {
+    fun sendEmail(
+        emailAddress: String,
+        title: String,
+        body: String,
+    )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailService.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.mail.service
+
+import com.backgu.amaker.mail.event.EmailEvent
+import org.springframework.stereotype.Service
+
+@Service
+class EmailService(
+    private val emailSender: EmailSender,
+    private val emailTemplateBuilder: EmailTemplateBuilder,
+) {
+    fun sendEmailEvent(emailEvent: EmailEvent) {
+        emailSender.sendEmail(
+            emailEvent.email,
+            emailEvent.title(),
+            emailTemplateBuilder.buildEmailContent(emailEvent.emailConstants.templateName, emailEvent.emailModel()),
+        )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailService.kt
@@ -1,18 +1,26 @@
 package com.backgu.amaker.mail.service
 
 import com.backgu.amaker.mail.event.EmailEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionalEventListener
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 class EmailService(
     private val emailSender: EmailSender,
     private val emailTemplateBuilder: EmailTemplateBuilder,
 ) {
-    fun sendEmailEvent(emailEvent: EmailEvent) {
+    @Async
+    @TransactionalEventListener
+    fun handleEmailEvent(event: EmailEvent) {
+        logger.info { "email send to ${event.email}" }
         emailSender.sendEmail(
-            emailEvent.email,
-            emailEvent.title(),
-            emailTemplateBuilder.buildEmailContent(emailEvent.emailConstants.templateName, emailEvent.emailModel()),
+            event.email,
+            event.title(),
+            emailTemplateBuilder.buildEmailContent(event.emailConstants.templateName, event.emailModel()),
         )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailTemplateBuilder.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/mail/service/EmailTemplateBuilder.kt
@@ -1,0 +1,8 @@
+package com.backgu.amaker.mail.service
+
+interface EmailTemplateBuilder {
+    fun buildEmailContent(
+        templateName: String,
+        model: Map<String, Any>,
+    ): String
+}

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceCreateDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/WorkspaceCreateDto.kt
@@ -2,4 +2,5 @@ package com.backgu.amaker.workspace.dto
 
 data class WorkspaceCreateDto(
     val name: String,
+    val inviteesEmails: Set<String>,
 )

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/request/WorkspaceCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/request/WorkspaceCreateRequest.kt
@@ -10,11 +10,11 @@ data class WorkspaceCreateRequest(
     @Schema(description = "워크스페이스 이름", example = "백구팀 워크스페이스")
     val name: String,
     @field:ValidEmailList(message = "이메일을 확인해주세요.")
-    val inviteesEmails: Set<String>? = null,
+    val inviteesEmails: Set<String> = emptySet(),
 ) {
     fun toDto() =
         WorkspaceCreateDto(
             name = name,
-            inviteesEmails = inviteesEmails ?: emptySet(),
+            inviteesEmails = inviteesEmails,
         )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/dto/request/WorkspaceCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/dto/request/WorkspaceCreateRequest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.workspace.dto.request
 
+import com.backgu.amaker.common.validator.ValidEmailList
 import com.backgu.amaker.workspace.dto.WorkspaceCreateDto
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
@@ -8,9 +9,12 @@ data class WorkspaceCreateRequest(
     @field:NotEmpty(message = "워크스페이스 이름은 필수입니다.")
     @Schema(description = "워크스페이스 이름", example = "백구팀 워크스페이스")
     val name: String,
+    @field:ValidEmailList(message = "이메일을 확인해주세요.")
+    val inviteesEmails: Set<String>? = null,
 ) {
     fun toDto() =
         WorkspaceCreateDto(
             name = name,
+            inviteesEmails = inviteesEmails ?: emptySet(),
         )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/event/WorkspaceInvitedEvent.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/event/WorkspaceInvitedEvent.kt
@@ -1,0 +1,23 @@
+package com.backgu.amaker.workspace.event
+
+import com.backgu.amaker.mail.constants.EmailConstants
+import com.backgu.amaker.mail.event.EmailEvent
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
+
+class WorkspaceInvitedEvent(
+    private val invitedUser: User,
+    private val workspace: Workspace,
+) : EmailEvent {
+    override val email: String = invitedUser.email
+    override val emailConstants: EmailConstants = EmailConstants.WORKSPACE_INVITED
+
+    override fun emailModel(): Map<String, Any> =
+        mapOf(
+            "name" to invitedUser.name,
+            "workspaceName" to workspace.name,
+            "workspaceId" to workspace.id,
+        )
+
+    override fun title(): String = String.format(emailConstants.title, invitedUser.name)
+}

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/event/WorkspaceJoinedEvent.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/event/WorkspaceJoinedEvent.kt
@@ -1,0 +1,22 @@
+package com.backgu.amaker.workspace.event
+
+import com.backgu.amaker.mail.constants.EmailConstants
+import com.backgu.amaker.mail.event.EmailEvent
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
+
+data class WorkspaceJoinedEvent(
+    val joiner: User,
+    private val workspace: Workspace,
+) : EmailEvent {
+    override val email = joiner.email
+    override val emailConstants = EmailConstants.WORKSPACE_JOINED
+
+    override fun emailModel(): Map<String, Any> =
+        mapOf(
+            "name" to joiner.name,
+            "workspaceName" to workspace.name,
+        )
+
+    override fun title(): String = String.format(emailConstants.title, joiner.name)
+}

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -4,6 +4,8 @@ import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.dto.ChatRoomDto
 import com.backgu.amaker.chat.service.ChatRoomService
 import com.backgu.amaker.chat.service.ChatRoomUserService
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.mail.event.EmailEvent
 import com.backgu.amaker.mail.service.EmailService
 import com.backgu.amaker.user.domain.User
@@ -47,7 +49,7 @@ class WorkspaceFacadeService(
 
         val invitees = workspaceCreateDto.inviteesEmails.map { userService.getByEmail(it) }
         invitees.forEach {
-            leader.isNonInvitee(it) || throw IllegalArgumentException("User ${it.id} is already in the workspace")
+            leader.isNonInvitee(it) || throw BusinessException(StatusCode.INVALID_WORKSPACE_CREATE)
             workspaceUserService.save(workspace.inviteWorkspace(it))
             eventPublisher.publishEvent(WorkspaceInvitedEvent(it, workspace))
         }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -44,7 +44,7 @@ class WorkspaceFacadeService(
 
         val invitees = workspaceCreateDto.inviteesEmails.map { userService.getByEmail(it) }
         invitees.forEach {
-            leader.isNonInvitee(it) || throw BusinessException(StatusCode.INVALID_WORKSPACE_CREATE)
+            if (!leader.isNonInvitee(it)) throw BusinessException(StatusCode.INVALID_WORKSPACE_CREATE)
             workspaceUserService.save(workspace.inviteWorkspace(it))
             eventPublisher.publishEvent(WorkspaceInvitedEvent(it, workspace))
         }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -6,8 +6,6 @@ import com.backgu.amaker.chat.service.ChatRoomService
 import com.backgu.amaker.chat.service.ChatRoomUserService
 import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.common.exception.StatusCode
-import com.backgu.amaker.mail.event.EmailEvent
-import com.backgu.amaker.mail.service.EmailService
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.service.UserService
 import com.backgu.amaker.workspace.domain.Workspace
@@ -19,10 +17,8 @@ import com.backgu.amaker.workspace.event.WorkspaceInvitedEvent
 import com.backgu.amaker.workspace.event.WorkspaceJoinedEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.event.TransactionalEventListener
 
 private val logger = KotlinLogging.logger {}
 
@@ -34,7 +30,6 @@ class WorkspaceFacadeService(
     private val workspaceUserService: WorkspaceUserService,
     private val chatRoomService: ChatRoomService,
     private val chatRoomUserService: ChatRoomUserService,
-    private val emailService: EmailService,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
@@ -107,12 +102,5 @@ class WorkspaceFacadeService(
             .addUser(user)
 
         return WorkspaceUserDto.of(workspaceUser)
-    }
-
-    @Async
-    @TransactionalEventListener
-    fun handleWorkspaceCreatedEvent(event: EmailEvent) {
-        logger.info { "email send to ${event.email}" }
-        emailService.sendEmailEvent(event)
     }
 }

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -14,6 +14,19 @@ spring:
       ddl-auto: update
     open-in-view: false
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+
 oauth:
   google:
     client-id: ${CLIENT_ID}
@@ -22,7 +35,7 @@ oauth:
     base-url: "https://accounts.google.com/o/oauth2/auth"
     oauth-url: "https://oauth2.googleapis.com"
     api-url: "https://www.googleapis.com"
-    client-name: Google
+    client-name: Googled
     scope: email,profile
 
 

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -35,7 +35,7 @@ oauth:
     base-url: "https://accounts.google.com/o/oauth2/auth"
     oauth-url: "https://oauth2.googleapis.com"
     api-url: "https://www.googleapis.com"
-    client-name: Googled
+    client-name: Google
     scope: email,profile
 
 

--- a/api/src/main/resources/templates/workspace-invite.html
+++ b/api/src/main/resources/templates/workspace-invite.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>워크스페이스 초대</title>
+</head>
+<body>
+  <h1>워크스페이스에 초대되었습니다.</h1>
+  <p th:text="${name} + '님은 ' + ${workspaceName} + '에 초대되었습니다.'">이승환님은 조별과제1 워크스페이스에 초대되었습니다.</p>
+  <a th:href="@{'https://a-maker.com/invite?id=' + ${workspaceId}}">초대 수락하시겠습니까?</a>
+</body>
+</html>

--- a/api/src/main/resources/templates/workspace-join.html
+++ b/api/src/main/resources/templates/workspace-join.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>워크스페이스 초대</title>
+</head>
+<body>
+  <h1>워크스페이스에 초대되었습니다.</h1>
+  <p th:text="${name} + '님은 ' + ${workspaceName} + '에 가입되었습니다.'">이승환님은 조별과제1 워크스페이스에 가입되었습니다.</p>
+</body>
+</html>

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceFixture.kt
@@ -22,10 +22,13 @@ class WorkspaceFixture(
             thumbnail = thumbnail,
         )
 
-        fun createWorkspaceRequest(name: String = "default-test") =
-            WorkspaceCreateDto(
-                name = name,
-            )
+        fun createWorkspaceRequest(
+            name: String = "default-test",
+            inviteesEmails: Set<String> = emptySet(),
+        ) = WorkspaceCreateDto(
+            name = name,
+            inviteesEmails = inviteesEmails,
+        )
 
         private fun nameBuilder(id: Any): String = "name-$id"
 

--- a/api/src/test/kotlin/com/backgu/amaker/mail/infra/FakeEmailSender.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/mail/infra/FakeEmailSender.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.mail.infra
+
+import com.backgu.amaker.common.annotation.IntegrationTestComponent
+import com.backgu.amaker.mail.service.EmailSender
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+@IntegrationTestComponent
+class FakeEmailSender : EmailSender {
+    override fun sendEmail(
+        emailAddress: String,
+        title: String,
+        body: String,
+    ) {
+        logger.info { "Test Sending email to $emailAddress with title $title and body $body" }
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -71,8 +71,9 @@ class WorkspaceFacadeServiceTest {
 
         // when & then
         assertThatThrownBy { workspaceFacadeService.createWorkspace(userId, request) }
-            .isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessage("User $userId is already in the workspace")
+            .isInstanceOf(BusinessException::class.java)
+            .extracting("statusCode")
+            .isEqualTo(StatusCode.INVALID_WORKSPACE_CREATE)
     }
 
     @Test

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -57,6 +57,25 @@ class WorkspaceFacadeServiceTest {
     }
 
     @Test
+    @DisplayName("워크스페이스 리더가 초대자로 들어가 있는 테스트")
+    fun createWorkspaceWithDuplicatedInvitees() {
+        // given
+        val userId = "tester"
+        val userEmail = "tester@gmail.com"
+        fixtures.user.createPersistedUser(id = userId, name = "tester", email = userEmail, picture = "http://server/picture-tester")
+
+        val inviteeEmail = "abc@gmail.com"
+        fixtures.user.createPersistedUser(name = "abc", email = inviteeEmail, picture = "http://server/picture-abc")
+
+        val request = createWorkspaceRequest("워크스페이스 생성", setOf(userEmail, inviteeEmail))
+
+        // when & then
+        assertThatThrownBy { workspaceFacadeService.createWorkspace(userId, request) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("User $userId is already in the workspace")
+    }
+
+    @Test
     @DisplayName("유저의 워크스페이스들 조회")
     fun findWorkspaces() {
         // given

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -13,6 +13,18 @@ spring:
     hibernate:
       ddl-auto: create
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: 123
+    password: 123
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 oauth:
   google:
     client-id: a

--- a/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/domain/User.kt
@@ -14,4 +14,6 @@ class User(
         val workspace = Workspace(name = name)
         return workspace
     }
+
+    fun isNonInvitee(invitee: User) = email != invitee.email
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
@@ -12,5 +12,7 @@ class Workspace(
 ) : BaseTime() {
     fun assignLeader(user: User): WorkspaceUser = WorkspaceUser.makeWorkspaceLeader(workspace = this, user = user)
 
+    fun inviteWorkspace(user: User): WorkspaceUser = WorkspaceUser(userId = user.id, workspaceId = id)
+
     fun createGroupChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.GROUP)
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -8,7 +8,7 @@ class WorkspaceUser(
     val userId: String,
     val workspaceId: Long,
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
-    var status: WorkspaceUserStatus,
+    var status: WorkspaceUserStatus = WorkspaceUserStatus.PENDING,
 ) : BaseTime() {
     fun activate() {
         this.status = WorkspaceUserStatus.ACTIVE

--- a/domain/src/test/kotlin/com/backgu/amaker/user/domain/UserTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/user/domain/UserTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 @DisplayName("User 테스트")
 class UserTest {
     @Test
+    @DisplayName("워크스페이스 생성 테스트")
     fun createWorkspace() {
         // given
         val user =
@@ -20,4 +21,19 @@ class UserTest {
         assertThat(workspace).isNotNull
         assertThat(workspace.name).isEqualTo("workspace1")
     }
+
+    @Test
+    @DisplayName("초대받은 사용자가 아닌지 확인")
+    fun isNonInvitee() {
+        // given
+        val leader = User(id = "me", name = "me", email = "me@gmail.com", picture = "/images/default_thumbnail.png")
+        val invitee = User(id = "invitee", name = "invitee", email = "invitee@gmail.com", picture = "/images/default_thumbnail.png")
+
+        // when
+        val result = leader.isNonInvitee(invitee)
+
+        // then
+        assertThat(result).isTrue
+    }
+
 }

--- a/domain/src/test/kotlin/com/backgu/amaker/user/domain/UserTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/user/domain/UserTest.kt
@@ -27,7 +27,13 @@ class UserTest {
     fun isNonInvitee() {
         // given
         val leader = User(id = "me", name = "me", email = "me@gmail.com", picture = "/images/default_thumbnail.png")
-        val invitee = User(id = "invitee", name = "invitee", email = "invitee@gmail.com", picture = "/images/default_thumbnail.png")
+        val invitee =
+            User(
+                id = "invitee",
+                name = "invitee",
+                email = "invitee@gmail.com",
+                picture = "/images/default_thumbnail.png",
+            )
 
         // when
         val result = leader.isNonInvitee(invitee)
@@ -35,5 +41,4 @@ class UserTest {
         // then
         assertThat(result).isTrue
     }
-
 }


### PR DESCRIPTION
# Why

* 트랜잭션을 필요로 하는 API에서 이메일 전송을 담당했기 때문에, 트랜잭션의 성공 여부에 따라 이메일을 전송할 수 있어야 했다.
* 이메일을 전송 부분을 블로킹하면 응답 시간이 오래걸리 때문에 비동기로 동작시커야 했다.
* API 요구사항도 좀 변경함
  * `workspaceCreateRequest` 에 초대자들의 이메일을 중복으로 등록할 수 없도록 처리함
  * `workspaceCreateRequest` 에 초대자들에 생성하는 유저의 이메일이 담겨있을 수 없도록 처리함

```kotlin
@Service
@Transactional(readOnly = true)
class WorkspaceFacadeService(
    private val userService: UserService,
    private val workspaceService: WorkspaceService,
    private val workspaceUserService: WorkspaceUserService,
    private val chatRoomService: ChatRoomService,
    private val chatRoomUserService: ChatRoomUserService,
    private val emailService: EmailService,
    private val eventPublisher: ApplicationEventPublisher,
) {
    @Transactional
    fun createWorkspace(
        userId: String,
        workspaceCreateDto: WorkspaceCreateDto,
    ): WorkspaceDto {
        val leader: User = userService.getById(userId)
        val workspace: Workspace = workspaceService.save(leader.createWorkspace(workspaceCreateDto.name))
        workspaceUserService.save(workspace.assignLeader(leader))
        eventPublisher.publishEvent(WorkspaceJoinedEvent(leader, workspace))

        val invitees = workspaceCreateDto.inviteesEmails.map { userService.getByEmail(it) }
        invitees.forEach {
            leader.isNonInvitee(it) || throw BusinessException(StatusCode.INVALID_WORKSPACE_CREATE)
            workspaceUserService.save(workspace.inviteWorkspace(it))
            eventPublisher.publishEvent(WorkspaceInvitedEvent(it, workspace))
        }

        val chatRoom: ChatRoom = chatRoomService.save(workspace.createGroupChatRoom())
        chatRoomUserService.save(chatRoom.addUser(leader))

        return WorkspaceDto.of(workspace)
    }

    @Async
    @TransactionalEventListener
    fun handleWorkspaceCreatedEvent(event: EmailEvent) {
        logger.info { "email send to ${event.email}" }
        emailService.sendEmailEvent(event)
    }
}
```

# How

[정리](https://velog.io/@dltmd202/%EC%9D%B4%EB%A9%94%EC%9D%BC-%EC%A0%84%EC%86%A1%EC%9D%84-%ED%8F%AC%ED%95%A8%ED%95%98%EB%8A%94-%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98)


# Result

![시간지연_결과](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/4a65ff77-d3a8-46b0-bd81-59e5ad653133)

![시간단축](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/3f9cce29-8e7e-4ca6-943f-06badd3dfaa6)

* 시간 단축함

# Prize

![스크린샷 2024-07-06 오후 7 50 25](https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/690a0f8a-afe9-46d3-96bf-e249e7fd8db1)

* 외부 인프라 의존도가 높아지면서 테스트 커버리지가 떨어짐

# Link

BG-175