### PR TITLE
[BG-178]: WS에서 채팅방의 메시지를 전파  (3h / 3h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
@@ -1,10 +1,12 @@
 package com.backgu.amaker.chat.controller
 
 import com.backgu.amaker.chat.dto.request.GeneralChatCreateRequest
+import com.backgu.amaker.chat.dto.response.ChatResponse
 import com.backgu.amaker.chat.service.ChatFacadeService
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.handler.annotation.SendTo
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -12,10 +14,9 @@ class ChatController(
     private val chatFacadeService: ChatFacadeService,
 ) {
     @MessageMapping("/chat-rooms/{chat-rooms-id}/general")
+    @SendTo("/sub/chat-rooms/{chat-rooms-id}")
     fun sendGeneralChat(
-        @Payload chat: GeneralChatCreateRequest,
+        @Payload generalChatCreateRequest: GeneralChatCreateRequest,
         @DestinationVariable("chat-rooms-id") chatRoomId: Long,
-    ) {
-        chatFacadeService.createGeneralChat(chat.toDto(), chatRoomId)
-    }
+    ): ChatResponse = ChatResponse.of(chatFacadeService.createGeneralChat(generalChatCreateRequest.toDto(), chatRoomId))
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
@@ -1,0 +1,28 @@
+package com.backgu.amaker.chat.dto.response
+
+import com.backgu.amaker.chat.domain.ChatType
+import com.backgu.amaker.chat.dto.ChatDto
+import java.time.LocalDateTime
+
+data class ChatResponse(
+    val id: Long,
+    val userId: String,
+    val chatRoomId: Long,
+    var content: String,
+    val chatType: ChatType,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun of(chatDto: ChatDto): ChatResponse =
+            ChatResponse(
+                id = chatDto.id,
+                userId = chatDto.userId,
+                chatRoomId = chatDto.chatRoomId,
+                content = chatDto.content,
+                chatType = chatDto.chatType,
+                createdAt = chatDto.createdAt,
+                updatedAt = chatDto.updatedAt,
+            )
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/config/WebSocketConfigTest.kt
@@ -1,76 +1,41 @@
 package com.backgu.amaker.chat.config
 
-import com.backgu.amaker.security.jwt.component.JwtComponent
+import com.backgu.amaker.fixture.StompFixtureFacade
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
-import org.springframework.lang.Nullable
-import org.springframework.messaging.converter.StringMessageConverter
-import org.springframework.messaging.simp.stomp.StompCommand
-import org.springframework.messaging.simp.stomp.StompHeaders
-import org.springframework.messaging.simp.stomp.StompSession
-import org.springframework.messaging.simp.stomp.StompSessionHandler
-import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
-import org.springframework.web.socket.WebSocketHttpHeaders
-import org.springframework.web.socket.client.standard.StandardWebSocketClient
-import org.springframework.web.socket.messaging.WebSocketStompClient
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 
 @DisplayName("웹소켓 설정 테스트")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class WebSocketConfigTest {
-    var stompClient: WebSocketStompClient = WebSocketStompClient(StandardWebSocketClient())
-
     @Autowired
-    lateinit var jwtComponent: JwtComponent
+    lateinit var fixtures: StompFixtureFacade
 
     @LocalServerPort
     var port: Int = 0
+
+    @BeforeEach
+    fun setup() {
+        fixtures.setup()
+    }
 
     @Test
     @DisplayName("웹소켓 연결 테스트")
     fun testWebSocketConnection() {
         // given
-        val jwtToken = jwtComponent.create("test", "ROLE_USER")
-        val headers =
-            StompHeaders().apply {
-                add("Authorization", "Bearer $jwtToken")
-            }
+        val userId = "test-user-id"
+        val headers = fixtures.createStompHeaders(userId)
 
         // when
-        val connectFuture: CompletableFuture<StompSession> =
-            stompClient.connectAsync("ws://localhost:$port/ws", WebSocketHttpHeaders(), headers, stompHandler)
-        val session: StompSession = connectFuture.get(1, TimeUnit.SECONDS)
+        val connectFuture = fixtures.connectToWebSocket(port, headers)
+        val session = connectFuture.get(1, TimeUnit.SECONDS)
 
         // then
         assertThat(session.isConnected).isTrue()
     }
-
-    @BeforeEach
-    fun setup() {
-        val webSocketClient = StandardWebSocketClient()
-        stompClient = WebSocketStompClient(webSocketClient)
-        stompClient.messageConverter = StringMessageConverter()
-    }
-
-    private val stompHandler: StompSessionHandler =
-        object : StompSessionHandlerAdapter() {
-            override fun handleException(
-                session: StompSession,
-                @Nullable command: StompCommand?,
-                headers: StompHeaders,
-                payload: ByteArray,
-                exception: Throwable,
-            ) = throw exception
-
-            override fun handleTransportError(
-                session: StompSession,
-                exception: Throwable,
-            ): Unit = throw exception
-        }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/chat/controller/ChatControllerTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/controller/ChatControllerTest.kt
@@ -1,0 +1,68 @@
+package com.backgu.amaker.chat.controller
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.dto.request.GeneralChatCreateRequest
+import com.backgu.amaker.chat.dto.response.ChatResponse
+import com.backgu.amaker.fixture.StompFixtureFacade
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+@DisplayName("ChatController 테스트")
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ChatControllerTest {
+    @Autowired
+    lateinit var fixtures: StompFixtureFacade
+
+    @LocalServerPort
+    var port: Int = 0
+
+    companion object {
+        private lateinit var fixture: StompFixtureFacade
+        private const val DEFAULT_USER_ID: String = "default-user-id"
+        private lateinit var chatRoom: ChatRoom
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp(
+            @Autowired fixture: StompFixtureFacade,
+        ) {
+            this.chatRoom = fixture.setup(DEFAULT_USER_ID)
+            this.fixture = fixture
+        }
+    }
+
+    @Test
+    @DisplayName("일반 채팅 전송 테스트")
+    fun sendGeneralChat() {
+        // given
+        val stompHeaders: StompHeaders = fixtures.createStompHeaders(DEFAULT_USER_ID)
+        val connectFuture: CompletableFuture<StompSession> =
+            fixtures.connectToWebSocket(port, stompHeaders)
+
+        val stompSession: StompSession = connectFuture.get(1, TimeUnit.SECONDS)
+        val subscribeToChatRoom: CompletableFuture<ChatResponse> =
+            fixtures.subscribeToChatRoom(stompSession, chatRoom.id)
+        val content = "Hello World"
+        val generalChatCreateRequest = GeneralChatCreateRequest(userId = DEFAULT_USER_ID, content = content)
+
+        // when
+        fixtures.sendMessage(stompSession, "/pub/chat-rooms/${chatRoom.id}/general", generalChatCreateRequest)
+
+        // then
+        val chatResponse: ChatResponse? = subscribeToChatRoom.get(5, TimeUnit.SECONDS)
+
+        assertThat(chatResponse).isNotNull
+        assertThat(chatResponse?.content).isEqualTo(content)
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/StompFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/StompFixtureFacade.kt
@@ -1,0 +1,103 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.dto.request.GeneralChatCreateRequest
+import com.backgu.amaker.chat.dto.response.ChatResponse
+import com.backgu.amaker.security.jwt.component.JwtComponent
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
+import org.springframework.lang.Nullable
+import org.springframework.messaging.converter.MappingJackson2MessageConverter
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompFrameHandler
+import org.springframework.messaging.simp.stomp.StompHeaders
+import org.springframework.messaging.simp.stomp.StompSession
+import org.springframework.messaging.simp.stomp.StompSessionHandler
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.WebSocketHttpHeaders
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
+import org.springframework.web.socket.messaging.WebSocketStompClient
+import java.util.concurrent.CompletableFuture
+
+@Component
+class StompFixtureFacade(
+    private val chatFixtureFacade: ChatFixtureFacade,
+    private val jwtComponent: JwtComponent,
+) {
+    val stompClient: WebSocketStompClient =
+        WebSocketStompClient(StandardWebSocketClient()).apply {
+            val messageConverter = MappingJackson2MessageConverter()
+            this.messageConverter = messageConverter
+            val objectMapper = messageConverter.objectMapper
+            objectMapper.registerModules(JavaTimeModule(), ParameterNamesModule())
+        }
+
+    fun setup(
+        userId: String = "test-user-id",
+        name: String = "김리더",
+        email: String = "leader@amaker.com",
+        workspaceName: String = "테스트 워크스페이스",
+    ): ChatRoom = chatFixtureFacade.setUp(userId, name, email, workspaceName)
+
+    fun createStompHeaders(userId: String): StompHeaders =
+        StompHeaders().apply {
+            add("Authorization", "Bearer ${jwtComponent.create(userId, "ROLE_USER")}")
+        }
+
+    fun connectToWebSocket(
+        port: Int,
+        headers: StompHeaders,
+    ): CompletableFuture<StompSession> =
+        stompClient.connectAsync(
+            "ws://localhost:$port/ws",
+            WebSocketHttpHeaders(),
+            headers,
+            stompHandler,
+        )
+
+    fun subscribeToChatRoom(
+        session: StompSession,
+        chatRoomId: Long,
+    ): CompletableFuture<ChatResponse> {
+        val future: CompletableFuture<ChatResponse> = CompletableFuture()
+        session.subscribe(
+            "/sub/chat-rooms/$chatRoomId",
+            object : StompFrameHandler {
+                override fun getPayloadType(headers: StompHeaders) = ChatResponse::class.java
+
+                override fun handleFrame(
+                    headers: StompHeaders,
+                    payload: Any?,
+                ) {
+                    future.complete(payload as ChatResponse)
+                }
+            },
+        )
+        return future
+    }
+
+    fun sendMessage(
+        session: StompSession,
+        destination: String,
+        request: GeneralChatCreateRequest,
+    ) {
+        session.send(destination, request)
+    }
+
+    val stompHandler: StompSessionHandler =
+        object : StompSessionHandlerAdapter() {
+            override fun handleException(
+                session: StompSession,
+                @Nullable command: StompCommand?,
+                headers: StompHeaders,
+                payload: ByteArray,
+                exception: Throwable,
+            ): Unit = throw exception
+
+            override fun handleTransportError(
+                session: StompSession,
+                exception: Throwable,
+            ): Unit = throw exception
+        }
+}


### PR DESCRIPTION
# Why
채팅방에 sub을 한 유저에게 채팅을 보내준다

# How
`@SendTo` 를 활용
테스트에서 직접 웹 소켓 전송을 테스트

# Result

`StompSession`을 이용하셔 sub 과 pub 을 해서
채팅방에 채팅이 전송되는 테스트 작성

```kotlin
 @Test
    @DisplayName("일반 채팅 전송 테스트")
    fun sendGeneralChat() {
        // given
        val stompHeaders: StompHeaders = fixtures.createStompHeaders(DEFAULT_USER_ID)
        val connectFuture: CompletableFuture<StompSession> =
            fixtures.connectToWebSocket(port, stompHeaders)

        val stompSession: StompSession = connectFuture.get(1, TimeUnit.SECONDS)
        val subscribeToChatRoom: CompletableFuture<ChatResponse> =
            fixtures.subscribeToChatRoom(stompSession, chatRoom.id)
        val content = "Hello World"
        val generalChatCreateRequest = GeneralChatCreateRequest(userId = DEFAULT_USER_ID, content = content)

        // when
        fixtures.sendMessage(stompSession, "/pub/chat-rooms/${chatRoom.id}/general", generalChatCreateRequest)

        // then
        val chatResponse: ChatResponse? = subscribeToChatRoom.get(5, TimeUnit.SECONDS)

        assertThat(chatResponse).isNotNull
        assertThat(chatResponse?.content).isEqualTo(content)
    }
```

# Link

BG-178