### PR TITLE
[BG-171]: 채팅방에 특정 시간부터 특정 개수의 채팅 목록을 조회하는 API를 구현한다. (4h / 3h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
@@ -1,20 +1,32 @@
 package com.backgu.amaker.chat.controller
 
 import com.backgu.amaker.chat.annotation.ChattingLoginUser
+import com.backgu.amaker.chat.dto.query.ChatQueryRequest
 import com.backgu.amaker.chat.dto.request.GeneralChatCreateRequest
+import com.backgu.amaker.chat.dto.response.ChatListResponse
 import com.backgu.amaker.chat.dto.response.ChatResponse
 import com.backgu.amaker.chat.service.ChatFacadeService
+import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.common.infra.ApiHandler
 import com.backgu.amaker.security.JwtAuthentication
+import org.springframework.http.ResponseEntity
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@RequestMapping("/api/v1")
 class ChatController(
     private val chatFacadeService: ChatFacadeService,
-) {
+    private val apiHandler: ApiHandler,
+) : ChatSwagger {
     @MessageMapping("/chat-rooms/{chat-rooms-id}/general")
     @SendTo("/sub/chat-rooms/{chat-rooms-id}")
     fun sendGeneralChat(
@@ -22,4 +34,21 @@ class ChatController(
         @DestinationVariable("chat-rooms-id") chatRoomId: Long,
         @ChattingLoginUser token: JwtAuthentication,
     ): ChatResponse = ChatResponse.of(chatFacadeService.createGeneralChat(generalChatCreateRequest.toDto(), token.id, chatRoomId))
+
+    @GetMapping("/chat-rooms/{chat-rooms-id}/chats")
+    override fun getPreviousChat(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @ModelAttribute chatQueryRequest: ChatQueryRequest,
+        @PathVariable("chat-rooms-id") chatRoomId: Long,
+    ): ResponseEntity<ApiResult<ChatListResponse>> =
+        ResponseEntity.ok().body(
+            apiHandler.onSuccess(
+                ChatListResponse.of(
+                    chatFacadeService.getPreviousChat(
+                        token.id,
+                        chatQueryRequest.toDto(chatRoomId),
+                    ),
+                ),
+            ),
+        )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatSwagger.kt
@@ -1,0 +1,31 @@
+package com.backgu.amaker.chat.controller
+
+import com.backgu.amaker.chat.dto.query.ChatQueryRequest
+import com.backgu.amaker.chat.dto.response.ChatListResponse
+import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.security.JwtAuthentication
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+
+@Tag(name = "chat", description = "채팅 API")
+interface ChatSwagger {
+    @Operation(summary = "채팅 조회", description = "커서 이전의 채팅 데이터를 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "채팅 조회 성공",
+            ),
+        ],
+    )
+    fun getPreviousChat(
+        token: JwtAuthentication,
+        @ModelAttribute chatQueryRequest: ChatQueryRequest,
+        @PathVariable("chat-rooms-id") chatRoomId: Long,
+    ): ResponseEntity<ApiResult<ChatListResponse>>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatListDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatListDto.kt
@@ -1,0 +1,23 @@
+package com.backgu.amaker.chat.dto
+
+import com.backgu.amaker.chat.domain.Chat
+
+data class ChatListDto(
+    val chatRoomId: Long,
+    val cursor: Long,
+    val size: Int,
+    val chatList: List<ChatDto>,
+) {
+    companion object {
+        fun of(
+            chatQuery: ChatQuery,
+            chatList: List<Chat>,
+        ): ChatListDto =
+            ChatListDto(
+                chatRoomId = chatQuery.chatRoomId,
+                cursor = chatQuery.cursor,
+                size = chatList.size,
+                chatList = chatList.map { ChatDto.of(it) },
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatQuery.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatQuery.kt
@@ -1,0 +1,7 @@
+package com.backgu.amaker.chat.dto
+
+data class ChatQuery(
+    val cursor: Long,
+    val chatRoomId: Long,
+    val size: Int,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/query/ChatQueryRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/query/ChatQueryRequest.kt
@@ -1,0 +1,20 @@
+package com.backgu.amaker.chat.dto.query
+
+import com.backgu.amaker.chat.dto.ChatQuery
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+data class ChatQueryRequest(
+    @field:NotNull(message = "채팅을 조회할 수 없습니다.")
+    @Schema(description = "채팅 커서", example = "101")
+    val cursor: Long,
+    @Schema(description = "읽어올 채팅의 개수", example = "100", defaultValue = "20")
+    val size: Int = 20,
+) {
+    fun toDto(chatRoomId: Long): ChatQuery =
+        ChatQuery(
+            cursor = cursor,
+            size = size,
+            chatRoomId = chatRoomId,
+        )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatListResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatListResponse.kt
@@ -1,0 +1,20 @@
+package com.backgu.amaker.chat.dto.response
+
+import com.backgu.amaker.chat.dto.ChatListDto
+
+class ChatListResponse(
+    val chatRoomId: Long,
+    val cursor: Long,
+    val size: Int,
+    val chatList: List<ChatResponse>,
+) {
+    companion object {
+        fun of(chatListDto: ChatListDto) =
+            ChatListResponse(
+                chatRoomId = chatListDto.chatRoomId,
+                cursor = chatListDto.cursor,
+                size = chatListDto.size,
+                chatList = chatListDto.chatList.map { ChatResponse.of(it) },
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatListResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatListResponse.kt
@@ -1,12 +1,18 @@
 package com.backgu.amaker.chat.dto.response
 
 import com.backgu.amaker.chat.dto.ChatListDto
+import io.swagger.v3.oas.annotations.media.Schema
 
 class ChatListResponse(
+    @Schema(description = "채팅방 ID", example = "1")
     val chatRoomId: Long,
+    @Schema(description = "채팅 커서", example = "101")
     val cursor: Long,
+    @Schema(description = "읽어올 채팅의 개수", example = "100", defaultValue = "20")
     val size: Int,
     val chatList: List<ChatResponse>,
+    @Schema(description = "다음 요청에 대한 커서", example = "100", defaultValue = "121")
+    val nextCursor: Long,
 ) {
     companion object {
         fun of(chatListDto: ChatListDto) =
@@ -15,6 +21,7 @@ class ChatListResponse(
                 cursor = chatListDto.cursor,
                 size = chatListDto.size,
                 chatList = chatListDto.chatList.map { ChatResponse.of(it) },
+                nextCursor = chatListDto.chatList.first().id,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
@@ -2,15 +2,23 @@ package com.backgu.amaker.chat.dto.response
 
 import com.backgu.amaker.chat.domain.ChatType
 import com.backgu.amaker.chat.dto.ChatDto
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class ChatResponse(
+    @Schema(description = "채팅 ID", example = "1")
     val id: Long,
+    @Schema(description = "유저 ID(현재 UUID)", example = "0000-0000-0000-0000000")
     val userId: String,
+    @Schema(description = "채팅방 ID", example = "1")
     val chatRoomId: Long,
+    @Schema(description = "채팅 내용", example = "안녕하세요")
     var content: String,
+    @Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK)", example = "GENERAL")
     val chatType: ChatType,
+    @Schema(description = "생성일시", example = "2021-05-29T00:00:00")
     val createdAt: LocalDateTime,
+    @Schema(description = "수정일시", example = "2021-05-29T00:00:00")
     val updatedAt: LocalDateTime,
 ) {
     companion object {

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRepository.kt
@@ -2,5 +2,15 @@ package com.backgu.amaker.chat.repository
 
 import com.backgu.amaker.chat.jpa.ChatEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface ChatRepository : JpaRepository<ChatEntity, String>
+interface ChatRepository : JpaRepository<ChatEntity, String> {
+    @Query(
+        "select c from Chat c where c.chatRoomId = :chatRoomId and c.id < :cursor order by c.id desc limit :size",
+    )
+    fun findTopByChatRoomIdLittleThanCursorLimitCount(
+        chatRoomId: Long,
+        cursor: Long,
+        size: Int,
+    ): List<ChatEntity>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
@@ -1,7 +1,10 @@
 package com.backgu.amaker.chat.service
 
+import com.backgu.amaker.chat.domain.Chat
 import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.dto.ChatDto
+import com.backgu.amaker.chat.dto.ChatListDto
+import com.backgu.amaker.chat.dto.ChatQuery
 import com.backgu.amaker.chat.dto.GeneralChatCreateDto
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.service.UserService
@@ -36,5 +39,17 @@ class ChatFacadeService(
                 ),
             ),
         )
+    }
+
+    fun getPreviousChat(
+        userId: String,
+        chatQuery: ChatQuery,
+    ): ChatListDto {
+        val user: User = userService.getById(userId)
+        val chatRoom: ChatRoom = chatRoomService.getById(chatQuery.chatRoomId)
+        chatRoomUserService.validateUserInChatRoom(user, chatRoom)
+
+        val chatList: List<Chat> = chatService.getChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
+        return ChatListDto.of(chatQuery, chatList)
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
@@ -49,7 +49,7 @@ class ChatFacadeService(
         val chatRoom: ChatRoom = chatRoomService.getById(chatQuery.chatRoomId)
         chatRoomUserService.validateUserInChatRoom(user, chatRoom)
 
-        val chatList: List<Chat> = chatService.getChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
+        val chatList: List<Chat> = chatService.findChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
         return ChatListDto.of(chatQuery, chatList)
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
@@ -13,4 +13,14 @@ class ChatService(
 ) {
     @Transactional
     fun save(chat: Chat): Chat = chatRepository.save(ChatEntity.of(chat)).toDomain()
+
+    fun getChatList(
+        chatRoomId: Long,
+        cursor: Long,
+        size: Int,
+    ): List<Chat> =
+        chatRepository
+            .findTopByChatRoomIdLittleThanCursorLimitCount(chatRoomId, cursor, size)
+            .asReversed()
+            .map { it.toDomain() }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
@@ -14,7 +14,7 @@ class ChatService(
     @Transactional
     fun save(chat: Chat): Chat = chatRepository.save(ChatEntity.of(chat)).toDomain()
 
-    fun getChatList(
+    fun findChatList(
         chatRoomId: Long,
         cursor: Long,
         size: Int,

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixture.kt
@@ -1,0 +1,42 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.chat.domain.Chat
+import com.backgu.amaker.chat.domain.ChatType
+import com.backgu.amaker.chat.jpa.ChatEntity
+import com.backgu.amaker.chat.repository.ChatRepository
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class ChatFixture(
+    private val chatRepository: ChatRepository,
+) {
+    fun createPersistedChat(
+        chatRoomId: Long,
+        userId: String,
+        message: String = "테스트 메시지 ${UUID.randomUUID()}",
+    ): Chat =
+        chatRepository
+            .save(
+                ChatEntity(
+                    chatRoomId = chatRoomId,
+                    userId = userId,
+                    content = message,
+                    chatType = ChatType.GENERAL,
+                ),
+            ).toDomain()
+
+    fun createPersistedChats(
+        chatRoomId: Long,
+        userId: String,
+        count: Int = 10,
+        messagePrefix: String = "테스트 메시지",
+    ): List<Chat> =
+        (0 until count).map {
+            createPersistedChat(chatRoomId, userId, "$messagePrefix $it")
+        }
+
+    fun deleteAll() {
+        chatRepository.deleteAll()
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixtureFacade.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component
 @Component
 class ChatFixtureFacade(
     val chatRoom: ChatRoomFixture,
+    val chat: ChatFixture,
     val chatRoomUser: ChatRoomUserFixture,
     val workspace: WorkspaceFixture,
     val workspaceUser: WorkspaceUserFixture,
@@ -38,6 +39,12 @@ class ChatFixtureFacade(
             userIds = workspaceUsers.map { it.userId },
         )
 
+        chat.createPersistedChats(
+            chatRoomId = chatRoom.id,
+            userId = leader.id,
+            count = 100,
+        )
+
         return chatRoom
     }
 
@@ -47,5 +54,6 @@ class ChatFixtureFacade(
         workspace.deleteAll()
         workspaceUser.deleteAll()
         user.deleteAll()
+        chat.deleteAll()
     }
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatEntity.kt
@@ -29,6 +29,7 @@ class ChatEntity(
 ) : BaseTimeEntity() {
     fun toDomain(): Chat =
         Chat(
+            id = id,
             chatRoomId = chatRoomId,
             userId = userId,
             content = content,


### PR DESCRIPTION
# Why

* 커서를 주었을 때, 그 커서 이전까지의  채팅을 조회해야 했다.
* 커서에 대한 이전 채팅을 조회하기 위해서는 커서의 역순으로 조회해야 한다.
  * 때문에 `desc`로 정렬해야 하지만, 결과는 'asc'로 정렬해야했다.
  * 일단은 쿼리로 풀기보다는 간단하게 쿼리된 결과를 `asReversed()` 로 정렬했다.
  * 추후에 개선해야할 것 같다.
```kotlin
@Query(
    "select c from Chat c where c.chatRoomId = :chatRoomId and c.id < :cursor order by c.id desc limit :size",
)
fun findTopByChatRoomIdLittleThanCursorLimitCount(
    chatRoomId: Long,
    cursor: Long,
    size: Int,
): List<ChatEntity>

fun getChatList(
    chatRoomId: Long,
    cursor: Long,
    size: Int,
): List<Chat> =
    chatRepository
        .findTopByChatRoomIdLittleThanCursorLimitCount(chatRoomId, cursor, size)
        .asReversed()
        .map { it.toDomain() }
```

# How

* 단순히 이전 채팅을 조회했다.
* 하지만 생각해야할 부분이 많다.
  * 처음 채팅방에 들어왔을 때 커서가 없을 때 어떻게 할 것인가?
  * 읽지 않은 채팅이 N개 쌓여있을 때 어떻게할 것인가?
  * etc

# Result

<img width="1624" alt="스크린샷 2024-07-08 오후 6 54 09" src="https://github.com/soma-baekgu/A-Maker-BE/assets/75921696/e5d75c93-f198-4065-b026-eadc56dfc22d">

* 점점 커버리지가 낮아지고 있는 것 같긴하다.

# Link
BG-171