### PR TITLE
[BG-253]: 커서 이후의 채팅을 조회하는 API를 개발한다. (4h / 3h)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm")
+    kotlin("kapt")
 }
 
 group = "com.backgu.amaker"
@@ -8,6 +9,8 @@ version = "0.0.1-SNAPSHOT"
 repositories {
     mavenCentral()
 }
+
+val queryDslVersion = "5.0.0"
 
 dependencies {
     implementation(project(":domain"))
@@ -19,15 +22,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    implementation("jakarta.persistence:jakarta.persistence-api")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    kapt("org.springframework.boot:spring-boot-configuration-processor")
+
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 
     testImplementation(kotlin("test"))
-}
-
-tasks.test {
-    useJUnitPlatform()
-}
-kotlin {
-    jvmToolchain(17)
 }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,6 +1,7 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("jvm")
-    kotlin("kapt")
 }
 
 group = "com.backgu.amaker"
@@ -9,8 +10,6 @@ version = "0.0.1-SNAPSHOT"
 repositories {
     mavenCentral()
 }
-
-val queryDslVersion = "5.0.0"
 
 dependencies {
     implementation(project(":domain"))
@@ -22,15 +21,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
-    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-    implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
-    implementation("jakarta.persistence:jakarta.persistence-api")
-    implementation("jakarta.annotation:jakarta.annotation-api")
-    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
-    kapt("org.springframework.boot:spring-boot-configuration-processor")
-
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 
     testImplementation(kotlin("test"))
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs += listOf("-Xjsr305=strict")
+        jvmTarget = "17"
+    }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatController.kt
@@ -35,7 +35,7 @@ class ChatController(
         @ChattingLoginUser token: JwtAuthentication,
     ): ChatResponse = ChatResponse.of(chatFacadeService.createGeneralChat(generalChatCreateRequest.toDto(), token.id, chatRoomId))
 
-    @GetMapping("/chat-rooms/{chat-rooms-id}/chats")
+    @GetMapping("/chat-rooms/{chat-rooms-id}/chats/previous")
     override fun getPreviousChat(
         @AuthenticationPrincipal token: JwtAuthentication,
         @ModelAttribute chatQueryRequest: ChatQueryRequest,
@@ -45,6 +45,23 @@ class ChatController(
             apiHandler.onSuccess(
                 ChatListResponse.of(
                     chatFacadeService.getPreviousChat(
+                        token.id,
+                        chatQueryRequest.toDto(chatRoomId),
+                    ),
+                ),
+            ),
+        )
+
+    @GetMapping("/chat-rooms/{chat-rooms-id}/chats/after")
+    override fun getAfterChat(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @ModelAttribute chatQueryRequest: ChatQueryRequest,
+        @PathVariable("chat-rooms-id") chatRoomId: Long,
+    ): ResponseEntity<ApiResult<ChatListResponse>> =
+        ResponseEntity.ok().body(
+            apiHandler.onSuccess(
+                ChatListResponse.of(
+                    chatFacadeService.getAfterChat(
                         token.id,
                         chatQueryRequest.toDto(chatRoomId),
                     ),

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatSwagger.kt
@@ -19,11 +19,26 @@ interface ChatSwagger {
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "채팅 조회 성공",
+                description = "커서 이후 채팅 조회 성공",
             ),
         ],
     )
     fun getPreviousChat(
+        token: JwtAuthentication,
+        @ModelAttribute chatQueryRequest: ChatQueryRequest,
+        @PathVariable("chat-rooms-id") chatRoomId: Long,
+    ): ResponseEntity<ApiResult<ChatListResponse>>
+
+    @Operation(summary = "채팅 조회", description = "커서 이후의 채팅 데이터를 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "커서 이후 채팅 조회 성공",
+            ),
+        ],
+    )
+    fun getAfterChat(
         token: JwtAuthentication,
         @ModelAttribute chatQueryRequest: ChatQueryRequest,
         @PathVariable("chat-rooms-id") chatRoomId: Long,

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatDto.kt
@@ -2,27 +2,43 @@ package com.backgu.amaker.chat.dto
 
 import com.backgu.amaker.chat.domain.Chat
 import com.backgu.amaker.chat.domain.ChatType
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.user.dto.UserDto
+import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
-data class ChatDto(
-    val id: Long = 0L,
-    val userId: String,
-    val chatRoomId: Long,
-    var content: String,
-    val chatType: ChatType,
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime,
-) {
-    companion object {
-        fun of(chat: Chat): ChatDto =
-            ChatDto(
-                id = chat.id,
-                userId = chat.userId,
-                chatRoomId = chat.chatRoomId,
-                content = chat.content,
-                chatType = chat.chatType,
-                createdAt = chat.createdAt,
-                updatedAt = chat.updatedAt,
-            )
+class ChatDto
+    @QueryProjection
+    constructor(
+        val id: Long = 0L,
+        val chatRoomId: Long,
+        var content: String,
+        val chatType: ChatType,
+        val createdAt: LocalDateTime,
+        val updatedAt: LocalDateTime,
+        userId: String,
+        userName: String,
+        userEmail: String,
+        userPicture: String,
+    ) {
+        companion object {
+            fun of(
+                chat: Chat,
+                user: User,
+            ): ChatDto =
+                ChatDto(
+                    id = chat.id,
+                    chatRoomId = chat.chatRoomId,
+                    content = chat.content,
+                    chatType = chat.chatType,
+                    createdAt = chat.createdAt,
+                    updatedAt = chat.updatedAt,
+                    userId = user.id,
+                    userName = user.name,
+                    userEmail = user.email,
+                    userPicture = user.picture,
+                )
+        }
+
+        val user: UserDto = UserDto(id = userId, name = userName, email = userEmail, picture = userPicture)
     }
-}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatListDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatListDto.kt
@@ -1,7 +1,5 @@
 package com.backgu.amaker.chat.dto
 
-import com.backgu.amaker.chat.domain.Chat
-
 data class ChatListDto(
     val chatRoomId: Long,
     val cursor: Long,
@@ -11,13 +9,13 @@ data class ChatListDto(
     companion object {
         fun of(
             chatQuery: ChatQuery,
-            chatList: List<Chat>,
+            chatList: List<ChatDto>,
         ): ChatListDto =
             ChatListDto(
                 chatRoomId = chatQuery.chatRoomId,
                 cursor = chatQuery.cursor,
                 size = chatList.size,
-                chatList = chatList.map { ChatDto.of(it) },
+                chatList = chatList,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatListDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatListDto.kt
@@ -4,12 +4,12 @@ data class ChatListDto(
     val chatRoomId: Long,
     val cursor: Long,
     val size: Int,
-    val chatList: List<ChatDto>,
+    val chatList: List<ChatWithUserDto>,
 ) {
     companion object {
         fun of(
             chatQuery: ChatQuery,
-            chatList: List<ChatDto>,
+            chatList: List<ChatWithUserDto>,
         ): ChatListDto =
             ChatListDto(
                 chatRoomId = chatQuery.chatRoomId,

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatWithUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatWithUserDto.kt
@@ -7,12 +7,12 @@ import com.backgu.amaker.user.dto.UserDto
 import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
-class ChatDto
+class ChatWithUserDto
     @QueryProjection
     constructor(
         val id: Long = 0L,
         val chatRoomId: Long,
-        var content: String,
+        val content: String,
         val chatType: ChatType,
         val createdAt: LocalDateTime,
         val updatedAt: LocalDateTime,
@@ -25,8 +25,8 @@ class ChatDto
             fun of(
                 chat: Chat,
                 user: User,
-            ): ChatDto =
-                ChatDto(
+            ): ChatWithUserDto =
+                ChatWithUserDto(
                     id = chat.id,
                     chatRoomId = chat.chatRoomId,
                     content = chat.content,

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 data class ChatResponse(
     @Schema(description = "채팅 ID", example = "1")
     val id: Long,
-    @Schema(description = "유저 ID(현재 UUID)", example = "0000-0000-0000-0000000")
     val user: ChatUserResponse,
     @Schema(description = "채팅방 ID", example = "1")
     val chatRoomId: Long,

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
@@ -9,7 +9,7 @@ data class ChatResponse(
     @Schema(description = "채팅 ID", example = "1")
     val id: Long,
     @Schema(description = "유저 ID(현재 UUID)", example = "0000-0000-0000-0000000")
-    val userId: String,
+    val user: ChatUserResponse,
     @Schema(description = "채팅방 ID", example = "1")
     val chatRoomId: Long,
     @Schema(description = "채팅 내용", example = "안녕하세요")
@@ -25,7 +25,7 @@ data class ChatResponse(
         fun of(chatDto: ChatDto): ChatResponse =
             ChatResponse(
                 id = chatDto.id,
-                userId = chatDto.userId,
+                user = ChatUserResponse.of(chatDto.user),
                 chatRoomId = chatDto.chatRoomId,
                 content = chatDto.content,
                 chatType = chatDto.chatType,

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatResponse.kt
@@ -1,14 +1,15 @@
 package com.backgu.amaker.chat.dto.response
 
 import com.backgu.amaker.chat.domain.ChatType
-import com.backgu.amaker.chat.dto.ChatDto
+import com.backgu.amaker.chat.dto.ChatWithUserDto
+import com.backgu.amaker.user.dto.response.UserResponse
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class ChatResponse(
     @Schema(description = "채팅 ID", example = "1")
     val id: Long,
-    val user: ChatUserResponse,
+    val user: UserResponse,
     @Schema(description = "채팅방 ID", example = "1")
     val chatRoomId: Long,
     @Schema(description = "채팅 내용", example = "안녕하세요")
@@ -21,15 +22,15 @@ data class ChatResponse(
     val updatedAt: LocalDateTime,
 ) {
     companion object {
-        fun of(chatDto: ChatDto): ChatResponse =
+        fun of(chatWithUserDto: ChatWithUserDto): ChatResponse =
             ChatResponse(
-                id = chatDto.id,
-                user = ChatUserResponse.of(chatDto.user),
-                chatRoomId = chatDto.chatRoomId,
-                content = chatDto.content,
-                chatType = chatDto.chatType,
-                createdAt = chatDto.createdAt,
-                updatedAt = chatDto.updatedAt,
+                id = chatWithUserDto.id,
+                user = UserResponse.of(chatWithUserDto.user),
+                chatRoomId = chatWithUserDto.chatRoomId,
+                content = chatWithUserDto.content,
+                chatType = chatWithUserDto.chatType,
+                createdAt = chatWithUserDto.createdAt,
+                updatedAt = chatWithUserDto.updatedAt,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatUserResponse.kt
@@ -1,0 +1,30 @@
+package com.backgu.amaker.chat.dto.response
+
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.user.dto.UserDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ChatUserResponse(
+    @Schema(description = "채팅유저 이름", example = "이승환")
+    val name: String,
+    @Schema(description = "채팅유저 이메일", example = "dltmd202@gmail.com")
+    val email: String,
+    @Schema(description = "채팅유저 프로필 사진", example = "http://127.0.0.1/images/default_thumbnail.png")
+    val picture: String,
+) {
+    companion object {
+        fun of(user: User): ChatUserResponse =
+            ChatUserResponse(
+                name = user.name,
+                email = user.email,
+                picture = user.picture,
+            )
+
+        fun of(user: UserDto): ChatUserResponse =
+            ChatUserResponse(
+                name = user.name,
+                email = user.email,
+                picture = user.picture,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatJpaRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.chat.repository
+
+import com.backgu.amaker.chat.jpa.ChatEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ChatJpaRepository : JpaRepository<ChatEntity, String>

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepository.kt
@@ -1,17 +1,17 @@
 package com.backgu.amaker.chat.repository
 
-import com.backgu.amaker.chat.dto.ChatDto
+import com.backgu.amaker.chat.dto.ChatWithUserDto
 
 interface ChatQueryRepository {
     fun findTopByChatRoomIdLittleThanCursorLimitCountWithUser(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<ChatDto>
+    ): List<ChatWithUserDto>
 
     fun findTopByChatRoomIdGreaterThanCursorLimitCountWithUser(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<ChatDto>
+    ): List<ChatWithUserDto>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepository.kt
@@ -1,0 +1,17 @@
+package com.backgu.amaker.chat.repository
+
+import com.backgu.amaker.chat.dto.ChatDto
+
+interface ChatQueryRepository {
+    fun findTopByChatRoomIdLittleThanCursorLimitCountWithUser(
+        chatRoomId: Long,
+        cursor: Long,
+        size: Int,
+    ): List<ChatDto>
+
+    fun findTopByChatRoomIdGreaterThanCursorLimitCountWithUser(
+        chatRoomId: Long,
+        cursor: Long,
+        size: Int,
+    ): List<ChatDto>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepositoryImpl.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepositoryImpl.kt
@@ -1,0 +1,65 @@
+package com.backgu.amaker.chat.repository
+
+import com.backgu.amaker.chat.dto.ChatDto
+import com.backgu.amaker.chat.dto.QChatDto
+import com.backgu.amaker.chat.jpa.QChatEntity.chatEntity
+import com.backgu.amaker.user.jpa.QUserEntity.userEntity
+import com.querydsl.jpa.impl.JPAQueryFactory
+
+class ChatQueryRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : ChatQueryRepository {
+    override fun findTopByChatRoomIdLittleThanCursorLimitCountWithUser(
+        chatRoomId: Long,
+        cursor: Long,
+        size: Int,
+    ): List<ChatDto> =
+        queryFactory
+            .select(
+                QChatDto(
+                    chatEntity.id,
+                    chatEntity.chatRoomId,
+                    chatEntity.content,
+                    chatEntity.chatType,
+                    chatEntity.createdAt,
+                    chatEntity.updatedAt,
+                    userEntity.id,
+                    userEntity.name,
+                    userEntity.email,
+                    userEntity.picture,
+                ),
+            ).from(chatEntity)
+            .innerJoin(userEntity)
+            .on(chatEntity.userId.eq(userEntity.id))
+            .where(chatEntity.chatRoomId.eq(chatRoomId).and(chatEntity.id.lt(cursor)))
+            .orderBy(chatEntity.id.desc())
+            .limit(size.toLong())
+            .fetch()
+
+    override fun findTopByChatRoomIdGreaterThanCursorLimitCountWithUser(
+        chatRoomId: Long,
+        cursor: Long,
+        size: Int,
+    ): List<ChatDto> =
+        queryFactory
+            .select(
+                QChatDto(
+                    chatEntity.id,
+                    chatEntity.chatRoomId,
+                    chatEntity.content,
+                    chatEntity.chatType,
+                    chatEntity.createdAt,
+                    chatEntity.updatedAt,
+                    userEntity.id,
+                    userEntity.name,
+                    userEntity.email,
+                    userEntity.picture,
+                ),
+            ).from(chatEntity)
+            .innerJoin(userEntity)
+            .on(chatEntity.userId.eq(userEntity.id))
+            .where(chatEntity.chatRoomId.eq(chatRoomId).and(chatEntity.id.gt(cursor)))
+            .orderBy(chatEntity.id.asc())
+            .limit(size.toLong())
+            .fetch()
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepositoryImpl.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatQueryRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.backgu.amaker.chat.repository
 
-import com.backgu.amaker.chat.dto.ChatDto
-import com.backgu.amaker.chat.dto.QChatDto
+import com.backgu.amaker.chat.dto.ChatWithUserDto
+import com.backgu.amaker.chat.dto.QChatWithUserDto
 import com.backgu.amaker.chat.jpa.QChatEntity.chatEntity
 import com.backgu.amaker.user.jpa.QUserEntity.userEntity
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -13,10 +13,10 @@ class ChatQueryRepositoryImpl(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<ChatDto> =
+    ): List<ChatWithUserDto> =
         queryFactory
             .select(
-                QChatDto(
+                QChatWithUserDto(
                     chatEntity.id,
                     chatEntity.chatRoomId,
                     chatEntity.content,
@@ -40,10 +40,10 @@ class ChatQueryRepositoryImpl(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<ChatDto> =
+    ): List<ChatWithUserDto> =
         queryFactory
             .select(
-                QChatDto(
+                QChatWithUserDto(
                     chatEntity.id,
                     chatEntity.chatRoomId,
                     chatEntity.content,

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRepository.kt
@@ -1,16 +1,5 @@
 package com.backgu.amaker.chat.repository
 
-import com.backgu.amaker.chat.jpa.ChatEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-
-interface ChatRepository : JpaRepository<ChatEntity, String> {
-    @Query(
-        "select c from Chat c where c.chatRoomId = :chatRoomId and c.id < :cursor order by c.id desc limit :size",
-    )
-    fun findTopByChatRoomIdLittleThanCursorLimitCount(
-        chatRoomId: Long,
-        cursor: Long,
-        size: Int,
-    ): List<ChatEntity>
-}
+interface ChatRepository :
+    ChatJpaRepository,
+    ChatQueryRepository

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
@@ -2,10 +2,17 @@ package com.backgu.amaker.chat.repository
 
 import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface ChatRoomUserRepository : JpaRepository<ChatRoomUserEntity, Long> {
     fun existsByUserIdAndChatRoomId(
         userId: String,
         chatRoomId: Long,
     ): Boolean
+
+    @Query("select c from ChatRoomUser c where c.userId = :userId and c.chatRoomId = :chatRoomId")
+    fun findByUserIdAndChatRoomId(
+        userId: String,
+        chatRoomId: Long,
+    ): ChatRoomUserEntity?
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
@@ -2,7 +2,6 @@ package com.backgu.amaker.chat.repository
 
 import com.backgu.amaker.chat.jpa.ChatRoomUserEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 
 interface ChatRoomUserRepository : JpaRepository<ChatRoomUserEntity, Long> {
     fun existsByUserIdAndChatRoomId(
@@ -10,7 +9,6 @@ interface ChatRoomUserRepository : JpaRepository<ChatRoomUserEntity, Long> {
         chatRoomId: Long,
     ): Boolean
 
-    @Query("select c from ChatRoomUser c where c.userId = :userId and c.chatRoomId = :chatRoomId")
     fun findByUserIdAndChatRoomId(
         userId: String,
         chatRoomId: Long,

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
@@ -1,9 +1,9 @@
 package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.ChatRoom
-import com.backgu.amaker.chat.dto.ChatDto
 import com.backgu.amaker.chat.dto.ChatListDto
 import com.backgu.amaker.chat.dto.ChatQuery
+import com.backgu.amaker.chat.dto.ChatWithUserDto
 import com.backgu.amaker.chat.dto.GeneralChatCreateDto
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.service.UserService
@@ -23,7 +23,7 @@ class ChatFacadeService(
         generalChatCreateDto: GeneralChatCreateDto,
         userId: String,
         chatRoomId: Long,
-    ): ChatDto {
+    ): ChatWithUserDto {
         val user: User = userService.getById(userId)
         val chatRoom: ChatRoom = chatRoomService.getById(chatRoomId)
 
@@ -31,7 +31,7 @@ class ChatFacadeService(
         val chat = chatService.save(chatRoom.createGeneralChat(user, chatRoom, generalChatCreateDto.content))
         chatRoomService.save(chatRoom.updateLastChatId(chat))
 
-        return ChatDto.of(chat, user)
+        return ChatWithUserDto.of(chat, user)
     }
 
     @Transactional
@@ -43,7 +43,7 @@ class ChatFacadeService(
         val chatRoomUser = chatRoomUserService.getByUserIdAndChatRoomId(userId, chatQuery.chatRoomId)
         chatRoomUserService.save(chatRoomUser.readLastChatOfChatRoom(chatRoom))
 
-        val chatList: List<ChatDto> =
+        val chatList: List<ChatWithUserDto> =
             chatService.findPreviousChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
         return ChatListDto.of(chatQuery, chatList)
     }
@@ -57,7 +57,7 @@ class ChatFacadeService(
         val chatRoomUser = chatRoomUserService.getByUserIdAndChatRoomId(userId, chatQuery.chatRoomId)
         chatRoomUserService.save(chatRoomUser.readLastChatOfChatRoom(chatRoom))
 
-        val chatList: List<ChatDto> =
+        val chatList: List<ChatWithUserDto> =
             chatService.findAfterChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
         return ChatListDto.of(chatQuery, chatList)
     }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
@@ -1,6 +1,5 @@
 package com.backgu.amaker.chat.service
 
-import com.backgu.amaker.chat.domain.Chat
 import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.dto.ChatDto
 import com.backgu.amaker.chat.dto.ChatListDto
@@ -29,27 +28,37 @@ class ChatFacadeService(
         val chatRoom: ChatRoom = chatRoomService.getById(chatRoomId)
 
         chatRoomUserService.validateUserInChatRoom(user, chatRoom)
+        val chat = chatService.save(chatRoom.createGeneralChat(user, chatRoom, generalChatCreateDto.content))
+        chatRoomService.save(chatRoom.updateLastChatId(chat))
 
-        return ChatDto.of(
-            chatService.save(
-                chatRoom.createGeneralChat(
-                    user = user,
-                    chatRoom = chatRoom,
-                    content = generalChatCreateDto.content,
-                ),
-            ),
-        )
+        return ChatDto.of(chat, user)
     }
 
+    @Transactional
     fun getPreviousChat(
         userId: String,
         chatQuery: ChatQuery,
     ): ChatListDto {
-        val user: User = userService.getById(userId)
-        val chatRoom: ChatRoom = chatRoomService.getById(chatQuery.chatRoomId)
-        chatRoomUserService.validateUserInChatRoom(user, chatRoom)
+        val chatRoom = chatRoomService.getById(chatQuery.chatRoomId)
+        val chatRoomUser = chatRoomUserService.getByUserIdAndChatRoomId(userId, chatQuery.chatRoomId)
+        chatRoomUserService.save(chatRoomUser.readLastChatOfChatRoom(chatRoom))
 
-        val chatList: List<Chat> = chatService.findChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
+        val chatList: List<ChatDto> =
+            chatService.findPreviousChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
+        return ChatListDto.of(chatQuery, chatList)
+    }
+
+    @Transactional
+    fun getAfterChat(
+        userId: String,
+        chatQuery: ChatQuery,
+    ): ChatListDto {
+        val chatRoom = chatRoomService.getById(chatQuery.chatRoomId)
+        val chatRoomUser = chatRoomUserService.getByUserIdAndChatRoomId(userId, chatQuery.chatRoomId)
+        chatRoomUserService.save(chatRoomUser.readLastChatOfChatRoom(chatRoom))
+
+        val chatList: List<ChatDto> =
+            chatService.findAfterChatList(chatQuery.chatRoomId, chatQuery.cursor, chatQuery.size)
         return ChatListDto.of(chatQuery, chatList)
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -7,12 +7,9 @@ import com.backgu.amaker.chat.repository.ChatRoomRepository
 import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.common.exception.StatusCode
 import com.backgu.amaker.workspace.domain.Workspace
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-
-private val logger = KotlinLogging.logger {}
 
 @Service
 @Transactional(readOnly = true)
@@ -25,20 +22,16 @@ class ChatRoomService(
     fun getGroupChatRoomByWorkspace(workspace: Workspace): ChatRoom =
         chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspace.id, ChatRoomType.GROUP)?.toDomain()
             ?: run {
-                // TODO : 로깅 전략 세워야 함
-                logger.error { "Group ChatRoom not found in Workspace ${workspace.id}" }
                 throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
             }
 
     fun findGroupChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
         chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.GROUP)?.toDomain() ?: run {
-            logger.error { "Group ChatRoom not found in Workspace $workspaceId" }
             throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
         }
 
     fun getById(chatRoomId: Long): ChatRoom =
         chatRoomRepository.findByIdOrNull(chatRoomId)?.toDomain() ?: run {
-            logger.error { "ChatRoom not found $chatRoomId" }
             throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
         }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
@@ -1,7 +1,7 @@
 package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.Chat
-import com.backgu.amaker.chat.dto.ChatDto
+import com.backgu.amaker.chat.dto.ChatWithUserDto
 import com.backgu.amaker.chat.jpa.ChatEntity
 import com.backgu.amaker.chat.repository.ChatRepository
 import org.springframework.stereotype.Service
@@ -19,7 +19,7 @@ class ChatService(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<ChatDto> =
+    ): List<ChatWithUserDto> =
         chatRepository
             .findTopByChatRoomIdLittleThanCursorLimitCountWithUser(chatRoomId, cursor, size)
             .asReversed()
@@ -28,7 +28,7 @@ class ChatService(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<ChatDto> =
+    ): List<ChatWithUserDto> =
         chatRepository
             .findTopByChatRoomIdGreaterThanCursorLimitCountWithUser(chatRoomId, cursor, size)
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatService.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.Chat
+import com.backgu.amaker.chat.dto.ChatDto
 import com.backgu.amaker.chat.jpa.ChatEntity
 import com.backgu.amaker.chat.repository.ChatRepository
 import org.springframework.stereotype.Service
@@ -14,13 +15,20 @@ class ChatService(
     @Transactional
     fun save(chat: Chat): Chat = chatRepository.save(ChatEntity.of(chat)).toDomain()
 
-    fun findChatList(
+    fun findPreviousChatList(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<Chat> =
+    ): List<ChatDto> =
         chatRepository
-            .findTopByChatRoomIdLittleThanCursorLimitCount(chatRoomId, cursor, size)
+            .findTopByChatRoomIdLittleThanCursorLimitCountWithUser(chatRoomId, cursor, size)
             .asReversed()
-            .map { it.toDomain() }
+
+    fun findAfterChatList(
+        chatRoomId: Long,
+        cursor: Long,
+        size: Int,
+    ): List<ChatDto> =
+        chatRepository
+            .findTopByChatRoomIdGreaterThanCursorLimitCountWithUser(chatRoomId, cursor, size)
 }

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
@@ -21,6 +21,7 @@ enum class StatusCode(
 
     // chat
     CHAT_ROOM_NOT_FOUND("4000", "채팅방이 존재하지 않습니다."),
+    CHAT_ROOM_USER_NOT_FOUND("4000", "접근할 수 없는 채팅방입니다."),
 
     // workspace
     WORKSPACE_NOT_FOUND("4000", "워크스페이스를 찾을 수 없습니다."),

--- a/api/src/main/kotlin/com/backgu/amaker/config/QuerydslConfiguration.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/config/QuerydslConfiguration.kt
@@ -1,0 +1,16 @@
+package com.backgu.amaker.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuerydslConfiguration {
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
+}

--- a/api/src/main/kotlin/com/backgu/amaker/user/dto/UserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/dto/UserDto.kt
@@ -1,0 +1,20 @@
+package com.backgu.amaker.user.dto
+
+import com.backgu.amaker.user.domain.User
+
+class UserDto(
+    val id: String,
+    val name: String,
+    val email: String,
+    val picture: String,
+) {
+    companion object {
+        fun of(user: User): UserDto =
+            UserDto(
+                id = user.id,
+                name = user.name,
+                email = user.email,
+                picture = user.picture,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/user/dto/response/UserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/dto/response/UserResponse.kt
@@ -1,10 +1,10 @@
-package com.backgu.amaker.chat.dto.response
+package com.backgu.amaker.user.dto.response
 
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.user.dto.UserDto
 import io.swagger.v3.oas.annotations.media.Schema
 
-data class ChatUserResponse(
+data class UserResponse(
     @Schema(description = "채팅유저 이름", example = "이승환")
     val name: String,
     @Schema(description = "채팅유저 이메일", example = "dltmd202@gmail.com")
@@ -13,15 +13,15 @@ data class ChatUserResponse(
     val picture: String,
 ) {
     companion object {
-        fun of(user: User): ChatUserResponse =
-            ChatUserResponse(
+        fun of(user: User): UserResponse =
+            UserResponse(
                 name = user.name,
                 email = user.email,
                 picture = user.picture,
             )
 
-        fun of(user: UserDto): ChatUserResponse =
-            ChatUserResponse(
+        fun of(user: UserDto): UserResponse =
+            UserResponse(
                 name = user.name,
                 email = user.email,
                 picture = user.picture,

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
@@ -59,7 +59,7 @@ class ChatFacadeServiceTest {
             )
 
         // then
-        assertThat(chatDto.userId).isEqualTo(DEFAULT_USER_ID)
+        assertThat(chatDto.user.id).isEqualTo(DEFAULT_USER_ID)
         assertThat(chatDto.chatRoomId).isEqualTo(chatRoom.id)
         assertThat(chatDto.content).isEqualTo(generalChatCreateDto.content)
     }
@@ -122,5 +122,44 @@ class ChatFacadeServiceTest {
         assertThat(previousChat.chatList).isEmpty()
         assertThat(previousChat.size).isEqualTo(previousChat.chatList.size)
         assertThat(previousChat.cursor).isEqualTo(currentChat.id)
+    }
+
+    @Test
+    @DisplayName("이후 채팅 조회 테스트")
+    fun getAfterChatTest() {
+        // given
+        val userId = "test-user-id"
+        val chatRoom: ChatRoom = fixture.setUp(userId = userId)
+        val prevChats = fixture.chat.createPersistedChats(chatRoom.id, userId, 10)
+        val currentChat: Chat = fixture.chat.createPersistedChat(chatRoom.id, userId, "현재 테스트 메시지")
+        val afterChats = fixture.chat.createPersistedChats(chatRoom.id, userId, 30)
+
+        // when
+        val findAfterChats: ChatListDto =
+            chatFacadeService.getAfterChat(userId, ChatQuery(currentChat.id, chatRoom.id, 10))
+
+        // then
+        assertThat(findAfterChats.chatList).hasSize(10)
+        assertThat(findAfterChats.size).isEqualTo(findAfterChats.chatList.size)
+        assertThat(findAfterChats.cursor).isNotEqualTo(prevChats.last().id)
+    }
+
+    @Test
+    @DisplayName("이전 채팅 조회 테스트")
+    fun getAfterChatTestWhenNoAfterChat() {
+        // given
+        val userId = "test-user-id"
+        val chatRoom: ChatRoom = fixture.setUp(userId = userId)
+        val prevChats: List<Chat> = fixture.chat.createPersistedChats(chatRoom.id, userId, 30)
+        val currentChat: Chat = fixture.chat.createPersistedChat(chatRoom.id, userId, "현재 테스트 메시지")
+        val afterChats = fixture.chat.createPersistedChats(chatRoom.id, userId, 10)
+
+        // when
+        val findPrevChats: ChatListDto =
+            chatFacadeService.getAfterChat(userId, ChatQuery(currentChat.id, chatRoom.id, 10))
+
+        // then
+        assertThat(findPrevChats.chatList).hasSize(10)
+        assertThat(findPrevChats.cursor).isNotEqualTo(prevChats.last().id)
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
@@ -132,7 +132,7 @@ class ChatFacadeServiceTest {
         val chatRoom: ChatRoom = fixture.setUp(userId = userId)
         val prevChats = fixture.chat.createPersistedChats(chatRoom.id, userId, 10)
         val currentChat: Chat = fixture.chat.createPersistedChat(chatRoom.id, userId, "현재 테스트 메시지")
-        val afterChats = fixture.chat.createPersistedChats(chatRoom.id, userId, 30)
+        fixture.chat.createPersistedChats(chatRoom.id, userId, 30)
 
         // when
         val findAfterChats: ChatListDto =
@@ -152,7 +152,7 @@ class ChatFacadeServiceTest {
         val chatRoom: ChatRoom = fixture.setUp(userId = userId)
         val prevChats: List<Chat> = fixture.chat.createPersistedChats(chatRoom.id, userId, 30)
         val currentChat: Chat = fixture.chat.createPersistedChat(chatRoom.id, userId, "현재 테스트 메시지")
-        val afterChats = fixture.chat.createPersistedChats(chatRoom.id, userId, 10)
+        fixture.chat.createPersistedChats(chatRoom.id, userId, 10)
 
         // when
         val findPrevChats: ChatListDto =

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
@@ -2,9 +2,9 @@ package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.Chat
 import com.backgu.amaker.chat.domain.ChatRoom
-import com.backgu.amaker.chat.dto.ChatDto
 import com.backgu.amaker.chat.dto.ChatListDto
 import com.backgu.amaker.chat.dto.ChatQuery
+import com.backgu.amaker.chat.dto.ChatWithUserDto
 import com.backgu.amaker.chat.dto.GeneralChatCreateDto
 import com.backgu.amaker.fixture.ChatFixtureFacade
 import org.assertj.core.api.Assertions.assertThat
@@ -51,7 +51,7 @@ class ChatFacadeServiceTest {
             )
 
         // when
-        val chatDto: ChatDto =
+        val chatDto: ChatWithUserDto =
             chatFacadeService.createGeneralChat(
                 generalChatCreateDto = generalChatCreateDto,
                 chatRoomId = chatRoom.id,

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
@@ -1,0 +1,40 @@
+package com.backgu.amaker.chat.service
+
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.fixture.ChatFixtureFacade
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@SpringBootTest
+@DisplayName("ChatRoomService 테스트")
+class ChatRoomServiceTest {
+    @Autowired
+    lateinit var chatRoomService: ChatRoomService
+
+    @Autowired
+    lateinit var fixture: ChatFixtureFacade
+
+    @Test
+    @DisplayName("일반 채팅 생성을 위한 테스트")
+    fun chatRoomSaveWithNewChat() {
+        // given
+        val uesr = fixture.user.createPersistedUser()
+        val workspace = fixture.workspace.createPersistedWorkspace()
+        val chatRoom = fixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        fixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(uesr.id))
+        val chat = fixture.chat.createPersistedChat(chatRoom.id, uesr.id)
+        val savedChatRoom = chatRoomService.save(chatRoom.updateLastChatId(chat))
+
+        // when
+        val findChatRoom = chatRoomService.getById(savedChatRoom.id)
+
+        // then
+        assertThat(findChatRoom.id).isEqualTo(savedChatRoom.id)
+        assertThat(findChatRoom.lastChatId).isEqualTo(chat.id)
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
@@ -23,11 +23,11 @@ class ChatRoomServiceTest {
     @DisplayName("일반 채팅 생성을 위한 테스트")
     fun chatRoomSaveWithNewChat() {
         // given
-        val uesr = fixture.user.createPersistedUser()
+        val tester = fixture.user.createPersistedUser()
         val workspace = fixture.workspace.createPersistedWorkspace()
         val chatRoom = fixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
-        fixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(uesr.id))
-        val chat = fixture.chat.createPersistedChat(chatRoom.id, uesr.id)
+        fixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(tester.id))
+        val chat = fixture.chat.createPersistedChat(chatRoom.id, tester.id)
         val savedChatRoom = chatRoomService.save(chatRoom.updateLastChatId(chat))
 
         // when

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomUserServiceTest.kt
@@ -2,10 +2,10 @@ package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.fixture.ChatFixtureFacade
 import com.backgu.amaker.user.domain.User
 import com.backgu.amaker.workspace.domain.Workspace
-import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
@@ -66,7 +66,6 @@ class ChatRoomUserServiceTest {
 
         // when & then
         assertThatThrownBy { chatRoomUserService.validateUserInChatRoom(user, chatRoom) }
-            .isInstanceOf(EntityNotFoundException::class.java)
-            .hasMessage("User ${user.id} is not in ChatRoom ${chatRoom.id}")
+            .isInstanceOf(BusinessException::class.java)
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatServiceTest.kt
@@ -1,0 +1,296 @@
+package com.backgu.amaker.chat.service
+
+import com.backgu.amaker.chat.domain.ChatRoomType
+import com.backgu.amaker.fixture.ChatFixtureFacade
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@DisplayName("ChatService 테스트")
+@Transactional
+@SpringBootTest
+class ChatServiceTest {
+    @Autowired
+    lateinit var chatService: ChatService
+
+    @Autowired
+    lateinit var chatFacadeFixture: ChatFixtureFacade
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun setUp(
+            @Autowired fixture: ChatFixtureFacade,
+        ) {
+            fixture.setUp(userId = "basic-data-set-up")
+        }
+    }
+
+    @Test
+    @DisplayName("커서 이전 채팅 조회 테스트")
+    fun findPreviousChatList() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser("findPreviousChatList")
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            12,
+        )
+
+        chatFacadeFixture.setUp("different-set-up")
+
+        // when
+        val chatList = chatService.findPreviousChatList(chatRoom.id, cursorChat.id, 5)
+
+        // then
+        assertThat(chatList.size).isEqualTo(5)
+        assertThat(chatList.first().id).isLessThan(cursorChat.id)
+        assertThat(chatList.last().id).isLessThan(cursorChat.id)
+        assertThat(chatList).isSortedAccordingTo(Comparator.comparingLong { it.id })
+    }
+
+    @Test
+    @DisplayName("커서 이전 채팅 조회 테스트: 개수가 부족할 때")
+    fun findPreviousChatListWithLessCount() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser()
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        chatFacadeFixture.setUp("different-set-up")
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            12,
+        )
+
+        // when
+        val chatList = chatService.findPreviousChatList(chatRoom.id, cursorChat.id, 15)
+
+        // then
+        assertThat(chatList.size).isEqualTo(10)
+        assertThat(chatList.first().id).isLessThan(cursorChat.id)
+        assertThat(chatList.last().id).isLessThan(cursorChat.id)
+        assertThat(chatList).isSortedAccordingTo(Comparator.comparingLong { it.id })
+    }
+
+    @Test
+    @DisplayName("커서 이전 채팅 조회 테스트: 개수가 맞아 떨어질 때")
+    fun findPreviousChatWithExactlyChatCount() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser()
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            12,
+        )
+
+        chatFacadeFixture.setUp("different-set-up")
+
+        // when
+        val chatList = chatService.findPreviousChatList(chatRoom.id, cursorChat.id, 10)
+
+        // then
+        assertThat(chatList.size).isEqualTo(10)
+        assertThat(chatList.first().id).isLessThan(cursorChat.id)
+        assertThat(chatList.last().id).isLessThan(cursorChat.id)
+        assertThat(chatList).isSortedAccordingTo(Comparator.comparingLong { it.id })
+    }
+
+    @Test
+    @DisplayName("커서 이전 채팅 조회 테스트: 개수가 0일 때")
+    fun findPreviousChatWithZeroCount() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser()
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            12,
+        )
+
+        // when
+        val chatList = chatService.findPreviousChatList(chatRoom.id, cursorChat.id, 10)
+
+        // then
+        assertThat(chatList.size).isEqualTo(0)
+    }
+
+    @Test
+    @DisplayName("커서 이후 채팅 조회 테스트")
+    fun findNextChatList() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser()
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        chatFacadeFixture.setUp("different-set-up")
+
+        // when
+        val chatList = chatService.findAfterChatList(chatRoom.id, cursorChat.id, 5)
+
+        // then
+        assertThat(chatList.size).isEqualTo(5)
+        assertThat(chatList.first().id).isGreaterThan(cursorChat.id)
+        assertThat(chatList.last().id).isGreaterThan(cursorChat.id)
+        assertThat(chatList).isSortedAccordingTo(Comparator.comparingLong { it.id })
+    }
+
+    @Test
+    @DisplayName("커서 이후 채팅 조회 테스트: 개수가 부족할 때")
+    fun findAfterChatListWithLessCount() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser()
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        // when
+        val chatList = chatService.findAfterChatList(chatRoom.id, cursorChat.id, 15)
+
+        // then
+        assertThat(chatList.size).isEqualTo(10)
+        assertThat(chatList.first().id).isGreaterThan(cursorChat.id)
+        assertThat(chatList.last().id).isGreaterThan(cursorChat.id)
+        assertThat(chatList).isSortedAccordingTo(Comparator.comparingLong { it.id })
+    }
+
+    @Test
+    @DisplayName("커서 이후 채팅 조회 테스트: 개수가 맞아 떨어질 때")
+    fun findAfterChatListWithExactlyCount() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser()
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        chatFacadeFixture.chat.createPersistedRandomUserChats(
+            chatRoom.id,
+            chatRoomUsers.map { it.id }.plus(user.id),
+            10,
+        )
+
+        // when
+        val chatList = chatService.findAfterChatList(chatRoom.id, cursorChat.id, 10)
+
+        // then
+        assertThat(chatList.size).isEqualTo(10)
+        assertThat(chatList.first().id).isGreaterThan(cursorChat.id)
+        assertThat(chatList.last().id).isGreaterThan(cursorChat.id)
+        assertThat(chatList).isSortedAccordingTo(Comparator.comparingLong { it.id })
+    }
+
+    @Test
+    @DisplayName("커서 이후 채팅 조회 테스트: 개수가 0일 때")
+    fun findAfterChatListWithZeroCount() {
+        // given
+        val user = chatFacadeFixture.user.createPersistedUser()
+        val workspace = chatFacadeFixture.workspace.createPersistedWorkspace()
+        val chatRoom = chatFacadeFixture.chatRoom.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
+        val chatRoomUsers = chatFacadeFixture.user.createPersistedUsers(10)
+        chatFacadeFixture.chatRoomUser.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
+
+        val cursorChat = chatFacadeFixture.chat.createPersistedChat(chatRoom.id, user.id)
+
+        // when
+        val chatList = chatService.findAfterChatList(chatRoom.id, cursorChat.id, 10)
+
+        // then
+        assertThat(chatList.size).isEqualTo(0)
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixture.kt
@@ -3,20 +3,21 @@ package com.backgu.amaker.fixture
 import com.backgu.amaker.chat.domain.Chat
 import com.backgu.amaker.chat.domain.ChatType
 import com.backgu.amaker.chat.jpa.ChatEntity
-import com.backgu.amaker.chat.repository.ChatRepository
+import com.backgu.amaker.chat.repository.ChatJpaRepository
 import org.springframework.stereotype.Component
 import java.util.UUID
+import kotlin.random.Random
 
 @Component
 class ChatFixture(
-    private val chatRepository: ChatRepository,
+    private val chatJpaRepository: ChatJpaRepository,
 ) {
     fun createPersistedChat(
         chatRoomId: Long,
         userId: String,
         message: String = "테스트 메시지 ${UUID.randomUUID()}",
     ): Chat =
-        chatRepository
+        chatJpaRepository
             .save(
                 ChatEntity(
                     chatRoomId = chatRoomId,
@@ -36,7 +37,17 @@ class ChatFixture(
             createPersistedChat(chatRoomId, userId, "$messagePrefix $it")
         }
 
+    fun createPersistedRandomUserChats(
+        chatRoomId: Long,
+        userIds: List<String>,
+        count: Int = 10,
+        messagePrefix: String = "테스트 메시지",
+    ): List<Chat> =
+        (0 until count).map {
+            createPersistedChat(chatRoomId, userIds[Random.nextInt(userIds.size)], "$messagePrefix $it")
+        }
+
     fun deleteAll() {
-        chatRepository.deleteAll()
+        chatJpaRepository.deleteAll()
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id("org.springframework.boot") version "3.3.0" apply false
     id("io.spring.dependency-management") version "1.1.5" apply false
@@ -15,13 +13,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-    }
-
-    tasks.withType<KotlinCompile> {
-        kotlinOptions {
-            freeCompilerArgs = listOf("-Xjsr305=strict")
-            jvmTarget = "17"
-        }
     }
 
     tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("org.springframework.boot") version "3.3.0" apply false
     id("io.spring.dependency-management") version "1.1.5" apply false
@@ -5,6 +7,7 @@ plugins {
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.jpa") version "1.9.24" apply false
     kotlin("plugin.spring") version "1.9.24" apply false
+    kotlin("kapt") version "1.9.24"
 }
 
 allprojects {
@@ -19,6 +22,13 @@ allprojects {
         useJUnitPlatform()
     }
 
+    tasks.withType<KotlinCompile> {
+        kotlinOptions {
+            freeCompilerArgs += listOf("-Xjsr305=strict")
+            jvmTarget = "17"
+        }
+    }
+
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 }
 
@@ -28,6 +38,7 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
     apply(plugin = "org.jetbrains.kotlin.plugin.jpa")
+    apply(plugin = "org.jetbrains.kotlin.kapt")
 
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -37,6 +48,13 @@ subprojects {
         implementation("io.github.oshai:kotlin-logging-jvm:5.1.1")
         implementation("com.mysql:mysql-connector-j:8.4.0")
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
+        implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+        implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
+        implementation("jakarta.persistence:jakarta.persistence-api")
+        implementation("jakarta.annotation:jakarta.annotation-api")
+        kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+        kapt("org.springframework.boot:spring-boot-configuration-processor")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     kotlin("jvm")
-    kotlin("kapt")
 }
 
 group = "com.backgu.amaker"
@@ -13,13 +10,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-    implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
-    implementation("jakarta.persistence:jakarta.persistence-api")
-    implementation("jakarta.annotation:jakarta.annotation-api")
-    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
-    kapt("org.springframework.boot:spring-boot-configuration-processor")
-
     testImplementation(kotlin("test"))
 }
 
@@ -29,11 +19,4 @@ tasks.getByName<Jar>("bootJar") {
 
 tasks.getByName<Jar>("jar") {
     enabled = true
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs += listOf("-Xjsr305=strict")
-        jvmTarget = "17"
-    }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,5 +1,8 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("jvm")
+    kotlin("kapt")
 }
 
 group = "com.backgu.amaker"
@@ -10,14 +13,14 @@ repositories {
 }
 
 dependencies {
-    testImplementation(kotlin("test"))
-}
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    implementation("jakarta.persistence:jakarta.persistence-api")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    kapt("org.springframework.boot:spring-boot-configuration-processor")
 
-tasks.test {
-    useJUnitPlatform()
-}
-kotlin {
-    jvmToolchain(17)
+    testImplementation(kotlin("test"))
 }
 
 tasks.getByName<Jar>("bootJar") {
@@ -26,4 +29,11 @@ tasks.getByName<Jar>("bootJar") {
 
 tasks.getByName<Jar>("jar") {
     enabled = true
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs += listOf("-Xjsr305=strict")
+        jvmTarget = "17"
+    }
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
@@ -7,6 +7,7 @@ class ChatRoom(
     val id: Long = 0L,
     val workspaceId: Long,
     val chatRoomType: ChatRoomType,
+    var lastChatId: Long? = null,
 ) : BaseTime() {
     fun addUser(user: User): ChatRoomUser = ChatRoomUser(userId = user.id, chatRoomId = id)
 
@@ -20,4 +21,9 @@ class ChatRoom(
         content = content,
         chatType = ChatType.GENERAL,
     )
+
+    fun updateLastChatId(chat: Chat): ChatRoom {
+        lastChatId = chat.id
+        return this
+    }
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomUser.kt
@@ -6,4 +6,10 @@ class ChatRoomUser(
     val id: Long = 0L,
     val userId: String,
     val chatRoomId: Long,
-) : BaseTime()
+    var lastReadChatId: Long? = null,
+) : BaseTime() {
+    fun readLastChatOfChatRoom(chatRoom: ChatRoom): ChatRoomUser {
+        lastReadChatId = chatRoom.lastChatId
+        return this
+    }
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomEntity.kt
@@ -23,12 +23,15 @@ class ChatRoomEntity(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     val chatRoomType: ChatRoomType,
+    @Column(nullable = true)
+    val lastChatId: Long? = null,
 ) : BaseTimeEntity() {
     fun toDomain(): ChatRoom =
         ChatRoom(
             id = id,
             workspaceId = workspaceId,
             chatRoomType = chatRoomType,
+            lastChatId = lastChatId,
         )
 
     companion object {
@@ -37,6 +40,7 @@ class ChatRoomEntity(
                 id = chatRoom.id,
                 workspaceId = chatRoom.workspaceId,
                 chatRoomType = chatRoom.chatRoomType,
+                lastChatId = chatRoom.lastChatId,
             )
     }
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomUserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomUserEntity.kt
@@ -19,8 +19,10 @@ class ChatRoomUserEntity(
     val userId: String,
     @Column(nullable = false)
     val chatRoomId: Long,
+    @Column(nullable = true)
+    var lastReadChatId: Long? = null,
 ) : BaseTimeEntity() {
-    fun toDomain(): ChatRoomUser = ChatRoomUser(id = id, userId = userId, chatRoomId = chatRoomId)
+    fun toDomain(): ChatRoomUser = ChatRoomUser(id = id, userId = userId, chatRoomId = chatRoomId, lastReadChatId = lastReadChatId)
 
     companion object {
         fun of(chatRoomUser: ChatRoomUser): ChatRoomUserEntity =
@@ -28,6 +30,7 @@ class ChatRoomUserEntity(
                 id = chatRoomUser.id,
                 userId = chatRoomUser.userId,
                 chatRoomId = chatRoomUser.chatRoomId,
+                lastReadChatId = chatRoomUser.lastReadChatId,
             )
     }
 }

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
@@ -40,4 +40,24 @@ class ChatRoomTest {
         assertThat(chat.chatType).isEqualTo(ChatType.GENERAL)
         assertThat(chat.content).isEqualTo(content)
     }
+
+    @Test
+    @DisplayName("채팅방의 마지막 채팅을 업데이트할 수 있다")
+    fun updateLastChatId() {
+        // given
+        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.GROUP)
+        val chat =
+            Chat(
+                userId = "user1",
+                chatRoomId = chatRoom.id,
+                content = "안녕하세요",
+                chatType = ChatType.GENERAL,
+            )
+
+        // when
+        val updatedChatRoom: ChatRoom = chatRoom.updateLastChatId(chat = chat)
+
+        // then
+        assertThat(updatedChatRoom.lastChatId).isEqualTo(chat.id)
+    }
 }


### PR DESCRIPTION
# Why

### 4H가 걸린 이유
* 기존에 커서 이전의 채팅을 조회하는 API가 있었기 때문에 거의 그대로 개발하면 될 것이라 생각해서 `3H`로 잡았음
* 하지만 이제 채팅 조회 API를 호출하면 일단 현재까지 읽은 채팅 아이디를 업데이트 하도록 로직이 추가됨
* 또 기존에는 채팅을 보낸 유저의 식별자만 보내주어 join할 필요가 없었지만, 채팅을 한 유저에 대한 정보도 같이 요청했기 때문에 조인을 했어야 했고, 엔티티 자체에 연관관계가 잡혀있지 않았기 때문에 `QueryDSL`의 `QueryProjection`을 활용하였음

### `QueryProjection` 대상 `DTO`
```kotlin
class ChatDto
    @QueryProjection
    constructor(
        val id: Long = 0L,
        val chatRoomId: Long,
        var content: String,
        val chatType: ChatType,
        val createdAt: LocalDateTime,
        val updatedAt: LocalDateTime,
        userId: String,
        userName: String,
        userEmail: String,
        userPicture: String,
    ) 
```

### `Repository`

```kotlin

class ChatQueryRepositoryImpl(
    private val queryFactory: JPAQueryFactory,
) : ChatQueryRepository {
    override fun findTopByChatRoomIdLittleThanCursorLimitCountWithUser(
        chatRoomId: Long,
        cursor: Long,
        size: Int,
    ): List<ChatDto> =
        queryFactory
            .select(
                QChatDto(
                    chatEntity.id,
                    // ...
                    userEntity.picture,
                ),
            ).from(chatEntity)
            .innerJoin(userEntity)
            .on(chatEntity.userId.eq(userEntity.id))
            .where(chatEntity.chatRoomId.eq(chatRoomId).and(chatEntity.id.lt(cursor)))
            .orderBy(chatEntity.id.desc())
            .limit(size.toLong())
            .fetch()

    override fun findTopByChatRoomIdGreaterThanCursorLimitCountWithUser(
        chatRoomId: Long,
        cursor: Long,
        size: Int,
    ): List<ChatDto> =
        queryFactory
            .select(
                QChatDto(
                    chatEntity.id,
                    // ...
                    userEntity.picture,
                ),
            ).from(chatEntity)
            .innerJoin(userEntity)
            .on(chatEntity.userId.eq(userEntity.id))
            .where(chatEntity.chatRoomId.eq(chatRoomId).and(chatEntity.id.gt(cursor)))
            .orderBy(chatEntity.id.asc())
            .limit(size.toLong())
            .fetch()
}
```

# Result


![스크린샷 2024-07-16 오후 11 36 15](https://github.com/user-attachments/assets/1746647e-a27c-4c9a-9c9e-1e8fe513789a)



# Link
BG-253