### PR TITLE
[BG-245]: 채팅방 생성 API를 개발한다 (4h / 3h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
@@ -6,6 +6,7 @@ import com.backgu.amaker.chat.service.ChatRoomFacadeService
 import com.backgu.amaker.common.dto.response.ApiResult
 import com.backgu.amaker.common.infra.ApiHandler
 import com.backgu.amaker.security.JwtAuthentication
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -25,7 +26,7 @@ class ChatRoomController(
     override fun createChatRoom(
         @AuthenticationPrincipal token: JwtAuthentication,
         @PathVariable("w-id") workspaceId: Long,
-        @RequestBody chatRoomCreateRequest: ChatRoomCreateRequest,
+        @RequestBody @Valid chatRoomCreateRequest: ChatRoomCreateRequest,
     ): ResponseEntity<ApiResult<ChatRoomResponse>> {
         val chatRoom = chatFacadeService.createChatRoom(token.id, workspaceId, chatRoomCreateRequest.toDto())
         return ResponseEntity

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
@@ -1,0 +1,37 @@
+package com.backgu.amaker.chat.controller
+
+import com.backgu.amaker.chat.dto.response.ChatRoomResponse
+import com.backgu.amaker.chat.service.ChatRoomFacadeService
+import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.common.infra.ApiHandler
+import com.backgu.amaker.security.JwtAuthentication
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+
+@RestController
+@RequestMapping("/api/v1")
+class ChatRoomController(
+    private val chatFacadeService: ChatRoomFacadeService,
+    private val apiHandler: ApiHandler,
+) : ChatRoomSwagger {
+    @PostMapping("/workspaces/{w-id}/chat-rooms")
+    override fun createChatRoom(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("w-id") workspaceId: Long,
+    ): ResponseEntity<ApiResult<ChatRoomResponse>> {
+        val chatRoom = chatFacadeService.createChatRoom(token.id, workspaceId)
+        return ResponseEntity
+            .created(
+                ServletUriComponentsBuilder
+                    .fromCurrentRequest()
+                    .path("/{id}")
+                    .buildAndExpand(chatRoom.chatRoomId)
+                    .toUri(),
+            ).body(apiHandler.onSuccess(ChatRoomResponse.of(chatRoom)))
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
@@ -22,10 +22,10 @@ class ChatRoomController(
     private val chatFacadeService: ChatRoomFacadeService,
     private val apiHandler: ApiHandler,
 ) : ChatRoomSwagger {
-    @PostMapping("/workspaces/{w-id}/chat-rooms")
+    @PostMapping("/workspaces/{workspace-id}/chat-rooms")
     override fun createChatRoom(
         @AuthenticationPrincipal token: JwtAuthentication,
-        @PathVariable("w-id") workspaceId: Long,
+        @PathVariable("workspace-id") workspaceId: Long,
         @RequestBody @Valid chatRoomCreateRequest: ChatRoomCreateRequest,
     ): ResponseEntity<ApiResult<ChatRoomResponse>> {
         val chatRoom = chatFacadeService.createChatRoom(token.id, workspaceId, chatRoomCreateRequest.toDto())

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomController.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.chat.controller
 
+import com.backgu.amaker.chat.dto.request.ChatRoomCreateRequest
 import com.backgu.amaker.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.chat.service.ChatRoomFacadeService
 import com.backgu.amaker.common.dto.response.ApiResult
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
@@ -23,8 +25,9 @@ class ChatRoomController(
     override fun createChatRoom(
         @AuthenticationPrincipal token: JwtAuthentication,
         @PathVariable("w-id") workspaceId: Long,
+        @RequestBody chatRoomCreateRequest: ChatRoomCreateRequest,
     ): ResponseEntity<ApiResult<ChatRoomResponse>> {
-        val chatRoom = chatFacadeService.createChatRoom(token.id, workspaceId)
+        val chatRoom = chatFacadeService.createChatRoom(token.id, workspaceId, chatRoomCreateRequest.toDto())
         return ResponseEntity
             .created(
                 ServletUriComponentsBuilder

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomSwagger.kt
@@ -26,7 +26,7 @@ interface ChatRoomSwagger {
     )
     fun createChatRoom(
         @AuthenticationPrincipal token: JwtAuthentication,
-        @PathVariable("w-id") workspaceId: Long,
+        @PathVariable("workspace-id") workspaceId: Long,
         @RequestBody chatRoomCreateRequest: ChatRoomCreateRequest,
     ): ResponseEntity<ApiResult<ChatRoomResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomSwagger.kt
@@ -1,0 +1,29 @@
+package com.backgu.amaker.chat.controller
+
+import com.backgu.amaker.chat.dto.response.ChatRoomResponse
+import com.backgu.amaker.common.dto.response.ApiResult
+import com.backgu.amaker.security.JwtAuthentication
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+
+@Tag(name = "chatRoom", description = "채팅방 API")
+interface ChatRoomSwagger {
+    @Operation(summary = "채팅방 생성", description = "채팅방을 생성한다")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "채팅방 생성 성공",
+            ),
+        ],
+    )
+    fun createChatRoom(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("w-id") workspaceId: Long,
+    ): ResponseEntity<ApiResult<ChatRoomResponse>>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/controller/ChatRoomSwagger.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.chat.controller
 
+import com.backgu.amaker.chat.dto.request.ChatRoomCreateRequest
 import com.backgu.amaker.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.common.dto.response.ApiResult
 import com.backgu.amaker.security.JwtAuthentication
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 
 @Tag(name = "chatRoom", description = "채팅방 API")
 interface ChatRoomSwagger {
@@ -25,5 +27,6 @@ interface ChatRoomSwagger {
     fun createChatRoom(
         @AuthenticationPrincipal token: JwtAuthentication,
         @PathVariable("w-id") workspaceId: Long,
+        @RequestBody chatRoomCreateRequest: ChatRoomCreateRequest,
     ): ResponseEntity<ApiResult<ChatRoomResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatRoomCreateDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatRoomCreateDto.kt
@@ -1,0 +1,5 @@
+package com.backgu.amaker.chat.dto
+
+class ChatRoomCreateDto(
+    val name: String,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatRoomDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/ChatRoomDto.kt
@@ -6,6 +6,7 @@ data class ChatRoomDto(
     val chatRoomId: Long,
     val workspaceId: Long,
     val chatRoomType: String,
+    val chatRoomName: String,
 ) {
     companion object {
         fun of(chatRoom: ChatRoom): ChatRoomDto =
@@ -13,6 +14,7 @@ data class ChatRoomDto(
                 chatRoomId = chatRoom.id,
                 workspaceId = chatRoom.workspaceId,
                 chatRoomType = chatRoom.chatRoomType.name,
+                chatRoomName = chatRoom.name,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/request/ChatRoomCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/request/ChatRoomCreateRequest.kt
@@ -1,0 +1,16 @@
+package com.backgu.amaker.chat.dto.request
+
+import com.backgu.amaker.chat.dto.ChatRoomCreateDto
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+class ChatRoomCreateRequest(
+    @field:NotBlank(message = "채팅방 이름을 입력해주세요.")
+    @Schema(description = "채팅방 이름", example = "자료조사방")
+    val name: String,
+) {
+    fun toDto() =
+        ChatRoomCreateDto(
+            name = name,
+        )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatRoomResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatRoomResponse.kt
@@ -8,7 +8,7 @@ data class ChatRoomResponse(
     val chatRoomId: Long,
     @Schema(description = "워크스페이스 id", example = "1")
     val workspaceId: Long,
-    @Schema(description = "채팅방 종류", example = "GROUP")
+    @Schema(description = "채팅방 종류", example = "DEFAULT")
     val chatRoomType: String,
 ) {
     companion object {

--- a/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatRoomResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/dto/response/ChatRoomResponse.kt
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class ChatRoomResponse(
     @Schema(description = "채팅방 id", example = "1")
     val chatRoomId: Long,
+    @Schema(description = "채팅방 이름", example = "기본 채팅방")
+    val chatRoomName: String,
     @Schema(description = "워크스페이스 id", example = "1")
     val workspaceId: Long,
     @Schema(description = "채팅방 종류", example = "DEFAULT")
@@ -17,6 +19,7 @@ data class ChatRoomResponse(
                 chatRoomId = chatRoomDto.chatRoomId,
                 workspaceId = chatRoomDto.workspaceId,
                 chatRoomType = chatRoomDto.chatRoomType,
+                chatRoomName = chatRoomDto.chatRoomName,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomFacadeService.kt
@@ -1,0 +1,33 @@
+package com.backgu.amaker.chat.service
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.dto.ChatRoomDto
+import com.backgu.amaker.user.service.UserService
+import com.backgu.amaker.workspace.service.WorkspaceService
+import com.backgu.amaker.workspace.service.WorkspaceUserService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ChatRoomFacadeService(
+    private val chatRoomService: ChatRoomService,
+    private val chatRoomUserService: ChatRoomUserService,
+    private val userService: UserService,
+    private val workspaceService: WorkspaceService,
+    private val workspaceUserService: WorkspaceUserService,
+) {
+    @Transactional
+    fun createChatRoom(
+        userId: String,
+        workspaceId: Long,
+    ): ChatRoomDto {
+        val user = userService.getById(userId)
+        val workspace = workspaceService.getById(workspaceId)
+        workspaceUserService.verifyUserHasAdminPrivileges(workspace, user)
+
+        val chatRoom: ChatRoom = chatRoomService.save(workspace.createCustomChatRoom())
+        chatRoomUserService.save(chatRoom.addUser(user))
+        return ChatRoomDto.of(chatRoom)
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomFacadeService.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.chat.dto.ChatRoomCreateDto
 import com.backgu.amaker.chat.dto.ChatRoomDto
 import com.backgu.amaker.user.service.UserService
 import com.backgu.amaker.workspace.service.WorkspaceService
@@ -21,12 +22,13 @@ class ChatRoomFacadeService(
     fun createChatRoom(
         userId: String,
         workspaceId: Long,
+        chatRoomCreateDto: ChatRoomCreateDto,
     ): ChatRoomDto {
         val user = userService.getById(userId)
         val workspace = workspaceService.getById(workspaceId)
         workspaceUserService.verifyUserHasAdminPrivileges(workspace, user)
 
-        val chatRoom: ChatRoom = chatRoomService.save(workspace.createCustomChatRoom())
+        val chatRoom: ChatRoom = chatRoomService.save(workspace.createCustomChatRoom(chatRoomCreateDto.name))
         chatRoomUserService.save(chatRoom.addUser(user))
         return ChatRoomDto.of(chatRoom)
     }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -25,7 +25,7 @@ class ChatRoomService(
                 throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
             }
 
-    fun findDefaultChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
+    fun getDefaultChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
         chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.DEFAULT)?.toDomain() ?: run {
             throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
         }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomService.kt
@@ -19,14 +19,14 @@ class ChatRoomService(
     @Transactional
     fun save(chatRoom: ChatRoom): ChatRoom = chatRoomRepository.save(ChatRoomEntity.of(chatRoom)).toDomain()
 
-    fun getGroupChatRoomByWorkspace(workspace: Workspace): ChatRoom =
-        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspace.id, ChatRoomType.GROUP)?.toDomain()
+    fun getDefaultChatRoomByWorkspace(workspace: Workspace): ChatRoom =
+        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspace.id, ChatRoomType.DEFAULT)?.toDomain()
             ?: run {
                 throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
             }
 
-    fun findGroupChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
-        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.GROUP)?.toDomain() ?: run {
+    fun findDefaultChatRoomByWorkspaceId(workspaceId: Long): ChatRoom =
+        chatRoomRepository.findByWorkspaceIdAndChatRoomType(workspaceId, ChatRoomType.DEFAULT)?.toDomain() ?: run {
             throw BusinessException(StatusCode.CHAT_ROOM_NOT_FOUND)
         }
 

--- a/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/common/exception/StatusCode.kt
@@ -34,4 +34,5 @@ enum class StatusCode(
 
     // workspaceUser
     WORKSPACE_UNREACHABLE("4000", "워크스페이스에 접근할 수 없습니다."),
+    WORKSPACE_UNAUTHORIZED("4000", "워크스페이스에 대한 관리자 권한이 없습니다."),
 }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceController.kt
@@ -61,15 +61,15 @@ class WorkspaceController(
             ),
         )
 
-    @GetMapping("{workspace-id}/group-chat-room")
-    override fun getGroupChatRoom(
+    @GetMapping("{workspace-id}/default-chat-room")
+    override fun getDefaultChatRoom(
         @PathVariable("workspace-id") workspaceId: Long,
         @AuthenticationPrincipal token: JwtAuthentication,
     ): ResponseEntity<ApiResult<ChatRoomResponse>> =
         ResponseEntity.ok().body(
             apiHandler.onSuccess(
                 ChatRoomResponse.of(
-                    workspaceFacadeService.getGroupChatRoom(workspaceId, token.id),
+                    workspaceFacadeService.getDefaultChatRoom(workspaceId, token.id),
                 ),
             ),
         )

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/controller/WorkspaceSwagger.kt
@@ -60,16 +60,16 @@ interface WorkspaceSwagger {
         @Parameter(hidden = true) token: JwtAuthentication,
     ): ResponseEntity<ApiResult<WorkspaceResponse>>
 
-    @Operation(summary = "그룹 채팅방 조회", description = "워크스페이스의 그룹 채팅방을 조회합니다.")
+    @Operation(summary = "기본 채팅방 조회", description = "워크스페이스의 기본 채팅방을 조회합니다.")
     @ApiResponses(
         value = [
             ApiResponse(
                 responseCode = "200",
-                description = "그룹 채팅방 조회 성공",
+                description = "기본 채팅방 조회 성공",
             ),
         ],
     )
-    fun getGroupChatRoom(
+    fun getDefaultChatRoom(
         @PathVariable
         @Parameter(description = "워크스페이스 ID", required = true, `in` = ParameterIn.PATH)
         workspaceId: Long,

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -94,12 +94,9 @@ class WorkspaceFacadeService(
 
         val workspaceUser = workspaceUserService.getWorkspaceUser(workspace, user)
         emailEventService.publishEmailEvent(WorkspaceJoinedEvent(user, workspace))
-        workspaceUser.activate()
-        workspaceUserService.save(workspaceUser)
+        workspaceUserService.save(workspaceUser.activate())
 
-        chatRoomService
-            .findGroupChatRoomByWorkspaceId(workspaceId)
-            .addUser(user)
+        chatRoomUserService.save(chatRoomService.findDefaultChatRoomByWorkspaceId(workspaceId).addUser(user))
 
         return WorkspaceUserDto.of(workspaceUser)
     }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -96,7 +96,7 @@ class WorkspaceFacadeService(
         emailEventService.publishEmailEvent(WorkspaceJoinedEvent(user, workspace))
         workspaceUserService.save(workspaceUser.activate())
 
-        chatRoomUserService.save(chatRoomService.findDefaultChatRoomByWorkspaceId(workspaceId).addUser(user))
+        chatRoomUserService.save(chatRoomService.getDefaultChatRoomByWorkspaceId(workspaceId).addUser(user))
 
         return WorkspaceUserDto.of(workspaceUser)
     }

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeService.kt
@@ -49,7 +49,7 @@ class WorkspaceFacadeService(
             emailEventService.publishEmailEvent(WorkspaceInvitedEvent(it, workspace))
         }
 
-        val chatRoom: ChatRoom = chatRoomService.save(workspace.createGroupChatRoom())
+        val chatRoom: ChatRoom = chatRoomService.save(workspace.createDefaultChatRoom())
         chatRoomUserService.save(chatRoom.addUser(leader))
 
         return WorkspaceDto.of(workspace)
@@ -72,7 +72,7 @@ class WorkspaceFacadeService(
         return workspaceService.getDefaultWorkspaceByUserId(user).let { WorkspaceDto.of(it) }
     }
 
-    fun getGroupChatRoom(
+    fun getDefaultChatRoom(
         workspaceId: Long,
         userId: String,
     ): ChatRoomDto {
@@ -81,7 +81,7 @@ class WorkspaceFacadeService(
 
         workspaceUserService.validUserInWorkspace(user, workspace)
 
-        return ChatRoomDto.of(chatRoomService.getGroupChatRoomByWorkspace(workspace))
+        return ChatRoomDto.of(chatRoomService.getDefaultChatRoomByWorkspace(workspace))
     }
 
     @Transactional

--- a/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/workspace/service/WorkspaceUserService.kt
@@ -28,12 +28,10 @@ class WorkspaceUserService(
         workspace: Workspace,
     ) {
         if (!workspaceUserRepository.existsByUserIdAndWorkspaceId(user.id, workspace.id)) {
-            logger.error { "User ${user.id} is not in Workspace ${workspace.id}" }
             throw BusinessException(StatusCode.WORKSPACE_UNREACHABLE)
         }
     }
 
-    @Transactional
     fun getWorkspaceUser(
         workspace: Workspace,
         user: User,
@@ -42,4 +40,12 @@ class WorkspaceUserService(
             .findByUserIdAndWorkspaceId(workspaceId = workspace.id, userId = user.id)
             ?.toDomain()
             ?: throw BusinessException(StatusCode.WORKSPACE_UNREACHABLE)
+
+    fun verifyUserHasAdminPrivileges(
+        workspace: Workspace,
+        user: User,
+    ) {
+        val workspaceUser = getWorkspaceUser(workspace, user)
+        if (!workspaceUser.isAdmin()) throw BusinessException(StatusCode.WORKSPACE_UNAUTHORIZED)
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatFacadeServiceTest.kt
@@ -195,7 +195,7 @@ class ChatFacadeServiceTest {
         val workspace = fixture.workspaceFixture.createPersistedWorkspace()
         fixture.workspaceUserFixture.createPersistedWorkspaceUser(workspace.id, userId, listOf(userId, otherUser.id))
 
-        val chatRoom = fixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = fixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         fixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, listOf(userId, otherUser.id))
 
         fixture.chatFixture.createPersistedChats(chatRoom.id, otherUser.id, 10)

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomFacadeServiceTest.kt
@@ -1,0 +1,48 @@
+package com.backgu.amaker.chat.service
+
+import com.backgu.amaker.chat.dto.ChatRoomCreateDto
+import com.backgu.amaker.fixture.ChatRoomFacadeFixture
+import com.backgu.amaker.workspace.domain.WorkspaceUserStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@DisplayName("ChatRoomFacadeService 테스트")
+@Transactional
+@SpringBootTest
+class ChatRoomFacadeServiceTest {
+    @Autowired
+    lateinit var chatRoomFacadeService: ChatRoomFacadeService
+
+    @Autowired
+    lateinit var fixtures: ChatRoomFacadeFixture
+
+    @Test
+    @DisplayName("채팅방 생성 테스트")
+    fun createChatRoom() {
+        // given
+        val leaderId = "tester"
+        val workspace = fixtures.setUp(userId = leaderId)
+        val activeWorkspaceMember = fixtures.userFixture.createPersistedUsers(10)
+        fixtures.workspaceUserFixture.createPersistedWorkspaceMember(
+            workspaceId = workspace.id,
+            memberIds = activeWorkspaceMember.map { it.id },
+        )
+        val inactiveWorkspaceMember = fixtures.userFixture.createPersistedUsers(10)
+        fixtures.workspaceUserFixture.createPersistedWorkspaceMember(
+            workspaceId = workspace.id,
+            memberIds = inactiveWorkspaceMember.map { it.id },
+            WorkspaceUserStatus.PENDING,
+        )
+
+        // when
+        val chatRoom = chatRoomFacadeService.createChatRoom(leaderId, workspace.id, ChatRoomCreateDto("test"))
+
+        // then
+        assertThat(chatRoom).isNotNull()
+        assertThat(chatRoom.workspaceId).isEqualTo(workspace.id)
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
@@ -25,7 +25,7 @@ class ChatRoomServiceTest {
         // given
         val tester = fixture.userFixture.createPersistedUser()
         val workspace = fixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = fixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = fixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         fixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(tester.id))
         val chat = fixture.chatFixture.createPersistedChat(chatRoom.id, tester.id)
         val savedChatRoom = chatRoomService.save(chatRoom.updateLastChatId(chat))

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomServiceTest.kt
@@ -1,7 +1,8 @@
 package com.backgu.amaker.chat.service
 
 import com.backgu.amaker.chat.domain.ChatRoomType
-import com.backgu.amaker.fixture.ChatFixtureFacade
+import com.backgu.amaker.fixture.ChatRoomFacadeFixture
+import com.backgu.amaker.workspace.domain.WorkspaceUserStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -17,7 +18,7 @@ class ChatRoomServiceTest {
     lateinit var chatRoomService: ChatRoomService
 
     @Autowired
-    lateinit var fixture: ChatFixtureFacade
+    lateinit var fixture: ChatRoomFacadeFixture
 
     @Test
     @DisplayName("일반 채팅 생성을 위한 테스트")
@@ -36,5 +37,32 @@ class ChatRoomServiceTest {
         // then
         assertThat(findChatRoom.id).isEqualTo(savedChatRoom.id)
         assertThat(findChatRoom.lastChatId).isEqualTo(chat.id)
+    }
+
+    @Test
+    @DisplayName("채팅방 생성을 위한 save 테스트")
+    fun saveChatRoom() {
+        // given
+        val leaderId = "tester"
+        val workspace = fixture.setUp(userId = leaderId)
+        val activeWorkspaceMember = fixture.userFixture.createPersistedUsers(10)
+        fixture.workspaceUserFixture.createPersistedWorkspaceMember(
+            workspaceId = workspace.id,
+            memberIds = activeWorkspaceMember.map { it.id },
+        )
+        val inactiveWorkspaceMember = fixture.userFixture.createPersistedUsers(10)
+        fixture.workspaceUserFixture.createPersistedWorkspaceMember(
+            workspaceId = workspace.id,
+            memberIds = inactiveWorkspaceMember.map { it.id },
+            WorkspaceUserStatus.PENDING,
+        )
+        val savedChatRoom = chatRoomService.save(workspace.createCustomChatRoom("test"))
+
+        // when
+        val findChatRoom = chatRoomService.getById(savedChatRoom.id)
+
+        // then
+        assertThat(findChatRoom.id).isEqualTo(savedChatRoom.id)
+        assertThat(findChatRoom.name).isEqualTo("test")
     }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatRoomUserServiceTest.kt
@@ -46,7 +46,7 @@ class ChatRoomUserServiceTest {
         val workspace: Workspace = fixtures.workspaceFixture.createPersistedWorkspace(name = "워크스페이스1")
         fixtures.workspaceUserFixture.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = userId)
         val chatRoom: ChatRoom =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+            fixtures.chatRoomFixture.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.DEFAULT)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(userId))
 
         // when & then

--- a/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/chat/service/ChatServiceTest.kt
@@ -38,7 +38,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser("findPreviousChatList")
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -75,7 +75,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -112,7 +112,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -149,7 +149,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -175,7 +175,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -212,7 +212,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -247,7 +247,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -282,7 +282,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })
@@ -302,7 +302,7 @@ class ChatServiceTest {
         // given
         val user = chatFacadeFixture.userFixture.createPersistedUser()
         val workspace = chatFacadeFixture.workspaceFixture.createPersistedWorkspace()
-        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.GROUP)
+        val chatRoom = chatFacadeFixture.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, arrayListOf(user.id))
         val chatRoomUsers = chatFacadeFixture.userFixture.createPersistedUsers(10)
         chatFacadeFixture.chatRoomUserFixture.createPersistedChatRoomUser(chatRoom.id, chatRoomUsers.map { it.id })

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFacadeFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFacadeFixture.kt
@@ -1,0 +1,50 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.user.domain.User
+import com.backgu.amaker.workspace.domain.Workspace
+import com.backgu.amaker.workspace.domain.WorkspaceUser
+import org.springframework.stereotype.Component
+
+@Component
+class ChatRoomFacadeFixture(
+    val chatRoomFixture: ChatRoomFixture,
+    val chatRoomUserFixture: ChatRoomUserFixture,
+    val workspaceFixture: WorkspaceFixture,
+    val workspaceUserFixture: WorkspaceUserFixture,
+    val userFixture: UserFixture,
+    val chatFixture: ChatFixture,
+) {
+    fun setUp(
+        userId: String = "test-user-id",
+        name: String = "김리더",
+        workspaceName: String = "테스트 워크스페이스",
+    ): Workspace {
+        val leader: User = userFixture.createPersistedUser(id = userId, name = name, email = "leader@amaker.com")
+        val workspace: Workspace = workspaceFixture.createPersistedWorkspace(name = workspaceName)
+        val members: List<User> = userFixture.createPersistedUsers(10)
+
+        val workspaceUsers: List<WorkspaceUser> =
+            workspaceUserFixture.createPersistedWorkspaceUser(
+                workspaceId = workspace.id,
+                leaderId = leader.id,
+                memberIds = members.map { it.id },
+            )
+
+        val chatRoom = chatRoomFixture.testGroupChatRoomSetUp(workspace = workspace)
+
+        chatRoomUserFixture.createPersistedChatRoomUser(
+            chatRoomId = chatRoom.id,
+            userIds = workspaceUsers.map { it.userId },
+        )
+
+        return workspace
+    }
+
+    fun deleteAll() {
+        chatRoomFixture.deleteAll()
+        chatRoomUserFixture.deleteAll()
+        workspaceFixture.deleteAll()
+        workspaceUserFixture.deleteAll()
+        userFixture.deleteAll()
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
@@ -21,7 +21,7 @@ class ChatRoomFixture(
             ).toDomain()
 
     fun testGroupChatRoomSetUp(workspace: Workspace): ChatRoom =
-        createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+        createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.DEFAULT)
 
     fun save(chatRoom: ChatRoom): ChatRoom = chatRoomRepository.save(ChatRoomEntity.of(chatRoom)).toDomain()
 

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatRoomFixture.kt
@@ -17,7 +17,7 @@ class ChatRoomFixture(
     ): ChatRoom =
         chatRoomRepository
             .save(
-                ChatRoomEntity(workspaceId = workspaceId, chatRoomType = chatRoomType),
+                ChatRoomEntity(workspaceId = workspaceId, name = "General", chatRoomType = chatRoomType),
             ).toDomain()
 
     fun testGroupChatRoomSetUp(workspace: Workspace): ChatRoom =

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/WorkspaceUserFixture.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.fixture
 
 import com.backgu.amaker.workspace.domain.WorkspaceRole
 import com.backgu.amaker.workspace.domain.WorkspaceUser
+import com.backgu.amaker.workspace.domain.WorkspaceUserStatus
 import com.backgu.amaker.workspace.jpa.WorkspaceUserEntity
 import com.backgu.amaker.workspace.repository.WorkspaceUserRepository
 import org.springframework.stereotype.Component
@@ -14,31 +15,44 @@ class WorkspaceUserFixture(
         workspaceId: Long,
         leaderId: String,
         memberIds: List<String> = emptyList(),
-    ): List<WorkspaceUser> {
-        val workspaceUsers: List<WorkspaceUser> =
-            listOf(
-                workspaceUserRepository
-                    .save(
-                        WorkspaceUserEntity(
-                            workspaceId = workspaceId,
-                            userId = leaderId,
-                            workspaceRole = WorkspaceRole.LEADER,
-                        ),
-                    ).toDomain(),
-            ) +
-                memberIds.map {
-                    workspaceUserRepository
-                        .save(
-                            WorkspaceUserEntity(
-                                workspaceId = workspaceId,
-                                userId = it,
-                                workspaceRole = WorkspaceRole.MEMBER,
-                            ),
-                        ).toDomain()
-                }
+        workspaceUserStatus: WorkspaceUserStatus = WorkspaceUserStatus.ACTIVE,
+    ): List<WorkspaceUser> =
+        this.createPersistedWorkspaceLeader(workspaceId, leaderId, workspaceUserStatus) +
+            this.createPersistedWorkspaceMember(workspaceId, memberIds, workspaceUserStatus)
 
-        return workspaceUsers
-    }
+    fun createPersistedWorkspaceLeader(
+        workspaceId: Long,
+        leaderId: String,
+        workspaceUserStatus: WorkspaceUserStatus = WorkspaceUserStatus.ACTIVE,
+    ): List<WorkspaceUser> =
+        listOf(
+            workspaceUserRepository
+                .save(
+                    WorkspaceUserEntity(
+                        workspaceId = workspaceId,
+                        userId = leaderId,
+                        workspaceRole = WorkspaceRole.LEADER,
+                        status = workspaceUserStatus,
+                    ),
+                ).toDomain(),
+        )
+
+    fun createPersistedWorkspaceMember(
+        workspaceId: Long,
+        memberIds: List<String> = emptyList(),
+        workspaceUserStatus: WorkspaceUserStatus = WorkspaceUserStatus.ACTIVE,
+    ): List<WorkspaceUser> =
+        memberIds.map {
+            workspaceUserRepository
+                .save(
+                    WorkspaceUserEntity(
+                        workspaceId = workspaceId,
+                        userId = it,
+                        workspaceRole = WorkspaceRole.MEMBER,
+                        status = workspaceUserStatus,
+                    ),
+                ).toDomain()
+        }
 
     fun deleteAll() {
         workspaceUserRepository.deleteAll()

--- a/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -152,7 +152,7 @@ class WorkspaceFacadeServiceTest {
         )
 
         val chatRoom: ChatRoom =
-            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.DEFAULT)
         fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(leaderId))
 
         // when
@@ -167,19 +167,19 @@ class WorkspaceFacadeServiceTest {
         assertThat(workspaceUser.workspaceRole).isEqualTo(WorkspaceRole.MEMBER)
     }
 
-    @DisplayName("워크스페이스의 그룹 채팅방을 조회")
-    fun getGroupChatRoom() {
+    @DisplayName("워크스페이스의 기본 채팅방을 조회")
+    fun getDefaultChatRoom() {
         // given
         val userId = "tester"
         fixtures.user.createPersistedUser(userId)
         val workspace = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
         fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = userId)
         val chatRoom =
-            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.GROUP)
+            fixtures.chatRoom.createPersistedChatRoom(workspaceId = workspace.id, chatRoomType = ChatRoomType.DEFAULT)
         fixtures.chatRoomUser.createPersistedChatRoomUser(chatRoomId = chatRoom.id, userIds = listOf(userId))
 
         // when
-        val result = workspaceFacadeService.getGroupChatRoom(workspace.id, userId)
+        val result = workspaceFacadeService.getDefaultChatRoom(workspace.id, userId)
 
         // then
         assertThat(result.chatRoomId).isEqualTo(chatRoom.id)

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 
 class ChatRoom(
     val id: Long = 0L,
+    var name: String,
     val workspaceId: Long,
     val chatRoomType: ChatRoomType,
     var lastChatId: Long? = null,

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomType.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoomType.kt
@@ -1,6 +1,6 @@
 package com.backgu.amaker.chat.domain
 
 enum class ChatRoomType {
-    GROUP,
-    DM,
+    DEFAULT,
+    CUSTOM,
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/jpa/ChatRoomEntity.kt
@@ -19,6 +19,8 @@ class ChatRoomEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
     @Column(nullable = false)
+    var name: String,
+    @Column(nullable = false)
     val workspaceId: Long,
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -34,6 +36,7 @@ class ChatRoomEntity(
             lastChatId = lastChatId,
             createdAt = createdAt,
             updatedAt = updatedAt,
+            name = name,
         )
 
     companion object {
@@ -43,6 +46,7 @@ class ChatRoomEntity(
                 workspaceId = chatRoom.workspaceId,
                 chatRoomType = chatRoom.chatRoomType,
                 lastChatId = chatRoom.lastChatId,
+                name = chatRoom.name,
             )
     }
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
@@ -14,5 +14,5 @@ class Workspace(
 
     fun inviteWorkspace(user: User): WorkspaceUser = WorkspaceUser(userId = user.id, workspaceId = id)
 
-    fun createGroupChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.GROUP)
+    fun createDefaultChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.DEFAULT)
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
@@ -12,6 +12,8 @@ class Workspace(
 ) : BaseTime() {
     fun assignLeader(user: User): WorkspaceUser = WorkspaceUser.makeWorkspaceLeader(workspace = this, user = user)
 
+    fun createCustomChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.CUSTOM)
+
     fun inviteWorkspace(user: User): WorkspaceUser = WorkspaceUser(userId = user.id, workspaceId = id)
 
     fun createDefaultChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.DEFAULT)

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/Workspace.kt
@@ -12,9 +12,10 @@ class Workspace(
 ) : BaseTime() {
     fun assignLeader(user: User): WorkspaceUser = WorkspaceUser.makeWorkspaceLeader(workspace = this, user = user)
 
-    fun createCustomChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.CUSTOM)
+    fun createCustomChatRoom(chatRoomName: String): ChatRoom =
+        ChatRoom(workspaceId = id, name = chatRoomName, chatRoomType = ChatRoomType.CUSTOM)
 
     fun inviteWorkspace(user: User): WorkspaceUser = WorkspaceUser(userId = user.id, workspaceId = id)
 
-    fun createDefaultChatRoom(): ChatRoom = ChatRoom(workspaceId = id, chatRoomType = ChatRoomType.DEFAULT)
+    fun createDefaultChatRoom(): ChatRoom = ChatRoom(workspaceId = id, name = "일반 채팅", chatRoomType = ChatRoomType.DEFAULT)
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -15,6 +15,8 @@ class WorkspaceUser(
         return this
     }
 
+    fun isAdmin() = this.workspaceRole == WorkspaceRole.LEADER
+
     companion object {
         fun makeWorkspaceLeader(
             workspace: Workspace,

--- a/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/workspace/domain/WorkspaceUser.kt
@@ -10,8 +10,9 @@ class WorkspaceUser(
     var workspaceRole: WorkspaceRole = WorkspaceRole.MEMBER,
     var status: WorkspaceUserStatus = WorkspaceUserStatus.PENDING,
 ) : BaseTime() {
-    fun activate() {
+    fun activate(): WorkspaceUser {
         this.status = WorkspaceUserStatus.ACTIVE
+        return this
     }
 
     companion object {

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
@@ -11,7 +11,7 @@ class ChatRoomTest {
     @DisplayName("채팅방에 사용자를 추가할 수 있다")
     fun addUser() {
         // given
-        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.GROUP)
+        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.DEFAULT)
         val user1 =
             User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
 
@@ -30,7 +30,7 @@ class ChatRoomTest {
         // given
         val user =
             User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
-        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.GROUP)
+        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.DEFAULT)
         val content = "안녕하세요"
 
         // when
@@ -45,7 +45,7 @@ class ChatRoomTest {
     @DisplayName("채팅방의 마지막 채팅을 업데이트할 수 있다")
     fun updateLastChatId() {
         // given
-        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.GROUP)
+        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.DEFAULT)
         val chat =
             Chat(
                 userId = "user1",

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
@@ -11,7 +11,7 @@ class ChatRoomTest {
     @DisplayName("채팅방에 사용자를 추가할 수 있다")
     fun addUser() {
         // given
-        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.DEFAULT)
+        val chatRoom = ChatRoom(workspaceId = 1, name = "General", chatRoomType = ChatRoomType.DEFAULT)
         val user1 =
             User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
 
@@ -30,7 +30,7 @@ class ChatRoomTest {
         // given
         val user =
             User(id = "user1", name = "user1", email = "user1@gmail.com", picture = "/images/default_thumbnail.png")
-        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.DEFAULT)
+        val chatRoom = ChatRoom(workspaceId = 1, name = "General", chatRoomType = ChatRoomType.DEFAULT)
         val content = "안녕하세요"
 
         // when
@@ -45,7 +45,7 @@ class ChatRoomTest {
     @DisplayName("채팅방의 마지막 채팅을 업데이트할 수 있다")
     fun updateLastChatId() {
         // given
-        val chatRoom = ChatRoom(workspaceId = 1, chatRoomType = ChatRoomType.DEFAULT)
+        val chatRoom = ChatRoom(workspaceId = 1, name = "General", chatRoomType = ChatRoomType.DEFAULT)
         val chat =
             Chat(
                 userId = "user1",

--- a/domain/src/test/kotlin/com/backgu/amaker/workspace/domain/WorkspaceTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/workspace/domain/WorkspaceTest.kt
@@ -29,8 +29,8 @@ class WorkspaceTest {
     }
 
     @Test
-    @DisplayName("워크스페이스에서 그룹 채팅방을 생성할 수 있다")
-    fun createGroupChatRoom() {
+    @DisplayName("워크스페이스에서 기본 채팅방을 생성할 수 있다")
+    fun createDefaultChatRoom() {
         // given
         val workspace = Workspace(name = "test")
         val leader =
@@ -38,11 +38,11 @@ class WorkspaceTest {
         workspace.assignLeader(leader)
 
         // when
-        val chatRoom: ChatRoom = workspace.createGroupChatRoom()
+        val chatRoom: ChatRoom = workspace.createDefaultChatRoom()
 
         // then
         assertThat(chatRoom).isNotNull
         assertThat(chatRoom.workspaceId).isEqualTo(workspace.id)
-        assertThat(chatRoom.chatRoomType).isEqualTo(ChatRoomType.GROUP)
+        assertThat(chatRoom.chatRoomType).isEqualTo(ChatRoomType.DEFAULT)
     }
 }


### PR DESCRIPTION
# Why

* 로직이 바뀌게 되면서 기존에 `DM`, `GROUP`이던 채팅방에서 `DEFAULT`, `CUSTOM` 이 두가지로 바뀌게 되어서 그 부분을 모두 수정해줌

* 로직 에러를 발견하여 수정함
```kotlin
@Transactional
fun activateWorkspaceUser(
    userId: String,
    workspaceId: Long,
): WorkspaceUserDto {
    val user = userService.getById(userId)
    val workspace = workspaceService.getById(workspaceId)

    val workspaceUser = workspaceUserService.getWorkspaceUser(workspace, user)
    emailEventService.publishEmailEvent(WorkspaceJoinedEvent(user, workspace))
    workspaceUserService.save(workspaceUser.activate())

    chatRoomUserService.save(chatRoomService.findDefaultChatRoomByWorkspaceId(workspaceId).addUser(user))

    return WorkspaceUserDto.of(workspaceUser)
}
```
  * 이 로직에서 처음엔 `chatRoomService.findDefaultChatRoomByWorkspaceId(workspaceId).addUser(user)` 이 레코드를 `save` 호출하는 것을 빼먹었다.
  * 하지만 직접적으로 facade에서 영속화 되었는지 확인할 수 없다보니 테스트를 어떻게 해야할지 고민이 되었다.
    * 그렇다고 모든 계층에 유닛테스트와 통합 테스트 계층을 하나 더 늘려서 테스트 하는 것은 또 부담이 되었다...

# Result

* 성공 요청

![스크린샷 2024-07-18 오후 9 19 13](https://github.com/user-attachments/assets/1996b9a8-4b08-4afc-9b7b-33cd6dbd9011)

*  채팅방 이름이 없을 때


![스크린샷 2024-07-18 오후 9 19 44](https://github.com/user-attachments/assets/fc1a4564-940a-4a7b-8f58-2075c450f00d)

# Reference

BG-245