### PR TITLE
[BG-292] ADMIN 유저에게 메트릭 엔드포인트 개방 한정

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
+    // monitoring
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 

--- a/api/src/main/kotlin/com/backgu/amaker/security/JwtAuthenticationToken.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/JwtAuthenticationToken.kt
@@ -11,7 +11,7 @@ class JwtAuthenticationToken : AbstractAuthenticationToken {
         this.principal = principal
     }
 
-    internal constructor(principal: JwtAuthentication, authorities: Collection<GrantedAuthority?>?) : super(
+    internal constructor(principal: JwtAuthentication, authorities: Collection<GrantedAuthority>) : super(
         authorities,
     ) {
         super.setAuthenticated(true)

--- a/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/security/config/SecurityConfig.kt
@@ -3,8 +3,10 @@ package com.backgu.amaker.security.config
 import com.backgu.amaker.security.filter.JwtAuthenticationTokenFilter
 import com.backgu.amaker.security.handler.AuthAccessDeniedHandler
 import com.backgu.amaker.security.handler.AuthEntryPoint
+import com.backgu.amaker.user.domain.UserRole
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -33,6 +35,10 @@ class SecurityConfig(
                 it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }.authorizeHttpRequests {
                 it
+                    .requestMatchers("/actuator/**")
+                    .hasRole(UserRole.ADMIN.value)
+                    .requestMatchers(HttpMethod.OPTIONS, "/**")
+                    .permitAll()
                     .requestMatchers(
                         "/auth/**",
                         "/api/v1/auth/**",

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     name: a-maker
 
   datasource:
-    url: jdbc:mysql://localhost:3306/amaker
+    url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -60,3 +60,16 @@ cors:
     - DELETE
     - PATCH
     - OPTIONS
+
+management:
+  endpoint:
+    shutdown:
+      enabled: true
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus

--- a/domain/src/main/kotlin/com/backgu/amaker/user/domain/UserRole.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/user/domain/UserRole.kt
@@ -4,7 +4,7 @@ enum class UserRole(
     var key: String,
     var value: String,
 ) {
-    USER("ROLE_USER", "User"),
-    MANAGER("ROLE_MANAGER", "Manager"),
-    ADMIN("ROLE_ADMIN", "Admin"),
+    USER("ROLE_USER", "USER"),
+    MANAGER("ROLE_MANAGER", "MANAGER"),
+    ADMIN("ROLE_ADMIN", "ADMIN"),
 }


### PR DESCRIPTION
# Why

특정 사용자 권한을 가져야 매트릭을 수집할 수 있도록 세팅

# Result

### 어드민 권한 요청

<img width="868" alt="스크린샷 2024-07-23 오후 3 24 36" src="https://github.com/user-attachments/assets/0866cf70-88f5-438a-b1ac-47df9d12d69a">

### 일반 유저 요청

<img width="1624" alt="스크린샷 2024-07-23 오후 3 25 34" src="https://github.com/user-attachments/assets/3a60791b-bef9-475c-a560-5275b14e6ed1">

# Link

BG-292