### PR TITLE
[BG-232]: 리플라이 이벤트 등록 API 구현 (4.5h / 3h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/repository/ChatRoomUserRepository.kt
@@ -17,4 +17,9 @@ interface ChatRoomUserRepository : JpaRepository<ChatRoomUserEntity, Long> {
     ): ChatRoomUserEntity?
 
     fun findByChatRoomIdIn(userIds: List<Long>): List<ChatRoomUserEntity>
+
+    fun findByUserIdInAndChatRoomId(
+        userIds: List<String>,
+        chatRoomId: Long,
+    ): List<ChatRoomUserEntity>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatFacadeService.kt
@@ -29,7 +29,7 @@ class ChatFacadeService(
         val user: User = userService.getById(userId)
         val chatRoom: ChatRoom = chatRoomService.getById(chatRoomId)
         chatRoomUserService.validateUserInChatRoom(user, chatRoom)
-        val chat: Chat = chatService.save(chatRoom.createChat(user, chatRoom, chatCreateDto.content))
+        val chat: Chat = chatService.save(chatRoom.createChat(user, chatCreateDto.content))
         chatRoomService.save(chatRoom.updateLastChatId(chat))
 
         return ChatWithUserDto.of(chat, user)

--- a/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/chat/service/ChatRoomUserService.kt
@@ -39,4 +39,14 @@ class ChatRoomUserService(
 
     fun findAllByChatRoomIds(chatRoomIds: List<Long>): List<ChatRoomUser> =
         chatRoomUserRepository.findByChatRoomIdIn(chatRoomIds).map { it.toDomain() }
+
+    fun validateUsersInChatRoom(
+        userIds: List<User>,
+        chatRoom: ChatRoom,
+    ) {
+        val chatRoomUsers = chatRoomUserRepository.findByUserIdInAndChatRoomId(userIds.map { it.id }, chatRoom.id)
+        if (chatRoomUsers.size != userIds.size) {
+            throw BusinessException(StatusCode.CHAT_ROOM_USER_NOT_FOUND)
+        }
+    }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/event/controller/EventController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/controller/EventController.kt
@@ -1,0 +1,41 @@
+package com.backgu.amaker.event.controller
+
+import com.backgu.amaker.event.dto.request.ReplyEventCreateRequest
+import com.backgu.amaker.event.service.EventFacadeService
+import com.backgu.amaker.security.JwtAuthentication
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+
+@RestController
+@RequestMapping("/api/v1")
+class EventController(
+    private val eventFacadeService: EventFacadeService,
+) : EventSwagger {
+    @PostMapping("/chat-rooms/{chat-room-id}/events/reply")
+    override fun createReplyEvent(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("chat-room-id") chatRoomId: Long,
+        @RequestBody @Valid request: ReplyEventCreateRequest,
+    ): ResponseEntity<Unit> =
+        ResponseEntity
+            .created(
+                ServletUriComponentsBuilder
+                    .fromCurrentContextPath()
+                    .path("/api/v1/events/{id}/reply")
+                    .buildAndExpand(
+                        eventFacadeService
+                            .createReplyEvent(
+                                token.id,
+                                chatRoomId,
+                                request.toDto(),
+                            ).id,
+                    ).toUri(),
+            ).build()
+}

--- a/api/src/main/kotlin/com/backgu/amaker/event/controller/EventSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/controller/EventSwagger.kt
@@ -1,0 +1,31 @@
+package com.backgu.amaker.event.controller
+
+import com.backgu.amaker.event.dto.request.ReplyEventCreateRequest
+import com.backgu.amaker.security.JwtAuthentication
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "event", description = "이벤트 API")
+interface EventSwagger {
+    @Operation(summary = "reply 이벤트 생성", description = "reply 이벤트 생성합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "reply 이벤트 생성 성공",
+            ),
+        ],
+    )
+    fun createReplyEvent(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("chat-room-id") chatRoomId: Long,
+        @RequestBody @Valid request: ReplyEventCreateRequest,
+    ): ResponseEntity<Unit>
+}

--- a/api/src/main/kotlin/com/backgu/amaker/event/dto/ReplyEventCreateDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/dto/ReplyEventCreateDto.kt
@@ -1,0 +1,13 @@
+package com.backgu.amaker.event.dto
+
+import java.time.LocalDateTime
+
+data class ReplyEventCreateDto(
+    val eventTitle: String,
+    val eventDetails: String,
+    val assignees: List<String>,
+    val deadLine: LocalDateTime,
+    val notificationStartHour: Int,
+    val notificationStartMinute: Int,
+    val interval: Int,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/event/dto/ReplyEventDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/dto/ReplyEventDto.kt
@@ -1,0 +1,25 @@
+package com.backgu.amaker.event.dto
+
+import com.backgu.amaker.event.domain.ReplyEvent
+import java.time.LocalDateTime
+
+class ReplyEventDto(
+    val id: Long,
+    val eventTitle: String,
+    val eventDetails: String,
+    val deadLine: LocalDateTime,
+    val notificationStartTime: LocalDateTime,
+    val notificationInterval: Int,
+) {
+    companion object {
+        fun of(replyEvent: ReplyEvent) =
+            ReplyEventDto(
+                id = replyEvent.id,
+                eventTitle = replyEvent.eventTitle,
+                eventDetails = replyEvent.eventDetails,
+                deadLine = replyEvent.deadLine,
+                notificationStartTime = replyEvent.notificationStartTime,
+                notificationInterval = replyEvent.notificationInterval,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/event/dto/request/ReplyEventCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/dto/request/ReplyEventCreateRequest.kt
@@ -1,0 +1,38 @@
+package com.backgu.amaker.event.dto.request
+
+import com.backgu.amaker.event.dto.ReplyEventCreateDto
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
+
+data class ReplyEventCreateRequest(
+    @Schema(description = "제목", example = "제목 어때요?")
+    @field:NotBlank(message = "이벤트 제목을 입력해주세요.")
+    val eventTitle: String,
+    @Schema(description = "상세내용", example = "상세내용 어때요?")
+    @field:NotBlank(message = "이벤트 내용을 입력해주세요.")
+    val eventDetails: String,
+    @Schema(description = "답변을 요청할 인원", example = "[\"user1\", \"user2\"]")
+    val assignees: List<String>,
+    @Schema(description = "마감 기한", example = "2021-08-01T00:00:00")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val deadLine: LocalDateTime,
+    @Schema(description = "알림 시작 시간", example = "1")
+    val notificationStartHour: Int,
+    @Schema(description = "알림 시작 분", example = "30")
+    val notificationStartMinute: Int,
+    @Schema(description = "알림 주기", example = "15")
+    val interval: Int,
+) {
+    fun toDto() =
+        ReplyEventCreateDto(
+            eventTitle = eventTitle,
+            eventDetails = eventDetails,
+            assignees = assignees,
+            deadLine = deadLine,
+            notificationStartMinute = notificationStartMinute,
+            notificationStartHour = notificationStartHour,
+            interval = interval,
+        )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/event/repository/ReplyEventAssignedRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/repository/ReplyEventAssignedRepository.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.event.repository
+
+import com.backgu.amaker.event.jpa.ReplyEventAssignedUserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReplyEventAssignedRepository : JpaRepository<ReplyEventAssignedUserEntity, Long>

--- a/api/src/main/kotlin/com/backgu/amaker/event/repository/ReplyEventRepository.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/repository/ReplyEventRepository.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.event.repository
+
+import com.backgu.amaker.event.jpa.ReplyEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReplyEventRepository : JpaRepository<ReplyEventEntity, Long>

--- a/api/src/main/kotlin/com/backgu/amaker/event/service/EventFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/service/EventFacadeService.kt
@@ -1,0 +1,55 @@
+package com.backgu.amaker.event.service
+
+import com.backgu.amaker.chat.domain.Chat
+import com.backgu.amaker.chat.domain.ChatType
+import com.backgu.amaker.chat.service.ChatRoomService
+import com.backgu.amaker.chat.service.ChatRoomUserService
+import com.backgu.amaker.chat.service.ChatService
+import com.backgu.amaker.event.dto.ReplyEventCreateDto
+import com.backgu.amaker.event.dto.ReplyEventDto
+import com.backgu.amaker.user.service.UserService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class EventFacadeService(
+    private val userService: UserService,
+    private val chatRoomService: ChatRoomService,
+    private val chatRoomUserService: ChatRoomUserService,
+    private val chatService: ChatService,
+    private val replyEventService: ReplyEventService,
+    private val replyEventAssignedUserService: ReplyEventAssignedUserService,
+) {
+    @Transactional
+    fun createReplyEvent(
+        userId: String,
+        chatRoomId: Long,
+        replyEventCreateDto: ReplyEventCreateDto,
+    ): ReplyEventDto {
+        val user = userService.getById(userId)
+        val chatRoom = chatRoomService.getById(chatRoomId)
+        chatRoomUserService.validateUserInChatRoom(user, chatRoom)
+
+        val chat: Chat = chatService.save(chatRoom.createChat(user, replyEventCreateDto.eventTitle, ChatType.REPLY))
+        chatRoomService.save(chatRoom.updateLastChatId(chat))
+
+        val replyEvent =
+            replyEventService.save(
+                chat.crateReplyEvent(
+                    replyEventCreateDto.deadLine,
+                    replyEventCreateDto.notificationStartHour,
+                    replyEventCreateDto.notificationStartMinute,
+                    replyEventCreateDto.interval,
+                    replyEventCreateDto.eventDetails,
+                ),
+            )
+
+        val userIds = userService.getAllByUserIds(replyEventCreateDto.assignees)
+        chatRoomUserService.validateUsersInChatRoom(userIds, chatRoom)
+
+        replyEventAssignedUserService.saveAll(replyEvent.createAssignedUsers(userIds))
+
+        return ReplyEventDto.of(replyEvent)
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/event/service/ReplyEventAssignedUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/service/ReplyEventAssignedUserService.kt
@@ -1,0 +1,25 @@
+package com.backgu.amaker.event.service
+
+import com.backgu.amaker.event.domain.ReplyEventAssignedUser
+import com.backgu.amaker.event.jpa.ReplyEventAssignedUserEntity
+import com.backgu.amaker.event.repository.ReplyEventAssignedRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReplyEventAssignedUserService(
+    private val replyEventAssignedRepository: ReplyEventAssignedRepository,
+) {
+    @Transactional
+    fun save(replyEventAssigned: ReplyEventAssignedUser): ReplyEventAssignedUser =
+        replyEventAssignedRepository.save(ReplyEventAssignedUserEntity.of(replyEventAssigned)).toDomain()
+
+    @Transactional
+    fun saveAll(createAssignedUsers: List<ReplyEventAssignedUser>): List<ReplyEventAssignedUser> =
+        replyEventAssignedRepository
+            .saveAll(
+                createAssignedUsers
+                    .map { ReplyEventAssignedUserEntity.of(it) },
+            ).map { it.toDomain() }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/event/service/ReplyEventService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/event/service/ReplyEventService.kt
@@ -1,0 +1,16 @@
+package com.backgu.amaker.event.service
+
+import com.backgu.amaker.event.domain.ReplyEvent
+import com.backgu.amaker.event.jpa.ReplyEventEntity
+import com.backgu.amaker.event.repository.ReplyEventRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReplyEventService(
+    private val replyEventRepository: ReplyEventRepository,
+) {
+    @Transactional
+    fun save(replyEvent: ReplyEvent): ReplyEvent = replyEventRepository.save(ReplyEventEntity.of(replyEvent)).toDomain()
+}

--- a/api/src/main/kotlin/com/backgu/amaker/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/user/service/UserService.kt
@@ -41,4 +41,14 @@ class UserService(
     fun findByEmail(email: String): User? = userRepository.findByEmail(email)?.toDomain()
 
     fun findAllByUserIds(userIds: List<String>): List<User> = userRepository.findAllByIdIn(userIds).map { it.toDomain() }
+
+    fun getAllByUserIds(userIds: List<String>): List<User> {
+        val users = userRepository.findAllByIdIn(userIds).map { it.toDomain() }
+
+        if (userIds.size != users.size) {
+            throw BusinessException(StatusCode.USER_NOT_FOUND)
+        }
+
+        return users
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/event/service/EventFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/event/service/EventFacadeServiceTest.kt
@@ -3,7 +3,7 @@ package com.backgu.amaker.event.service
 import com.backgu.amaker.chat.domain.ChatRoom
 import com.backgu.amaker.event.dto.ReplyEventCreateDto
 import com.backgu.amaker.fixture.EventFixtureFacade
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired

--- a/api/src/test/kotlin/com/backgu/amaker/event/service/EventFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/event/service/EventFacadeServiceTest.kt
@@ -1,0 +1,65 @@
+package com.backgu.amaker.event.service
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import com.backgu.amaker.event.dto.ReplyEventCreateDto
+import com.backgu.amaker.fixture.EventFixtureFacade
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import kotlin.test.Test
+
+@DisplayName("EventFacadeService 테스트")
+@Transactional
+@SpringBootTest
+class EventFacadeServiceTest {
+    @Autowired
+    lateinit var eventFacadeService: EventFacadeService
+
+    companion object {
+        private lateinit var fixtures: EventFixtureFacade
+        private const val DEFAULT_USER_ID: String = "default-user"
+        lateinit var chatRoom: ChatRoom
+
+        @JvmStatic
+        @BeforeAll
+        fun setUp(
+            @Autowired fixtures: EventFixtureFacade,
+        ) {
+            chatRoom = fixtures.setUp(DEFAULT_USER_ID)
+            this.fixtures = fixtures
+        }
+    }
+
+    @Test
+    @DisplayName("reply 이벤트 생성 테스트")
+    fun createReplyEvent() {
+        // given
+
+        val replyEventCreateDto =
+            ReplyEventCreateDto(
+                eventTitle = "eventTitle",
+                deadLine = LocalDateTime.now().plusDays(1),
+                notificationStartHour = 1,
+                notificationStartMinute = 30,
+                interval = 10,
+                eventDetails = "eventDetails",
+                assignees = listOf(DEFAULT_USER_ID),
+            )
+
+        // when
+        val replyEvent =
+            eventFacadeService.createReplyEvent(
+                userId = DEFAULT_USER_ID,
+                chatRoomId = chatRoom.id,
+                replyEventCreateDto = replyEventCreateDto,
+            )
+
+        // then
+        assertThat(replyEvent).isNotNull()
+        assertThat(replyEvent.deadLine).isEqualTo(replyEventCreateDto.deadLine)
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/ChatFixture.kt
@@ -32,20 +32,36 @@ class ChatFixture(
         userId: String,
         count: Int = 10,
         messagePrefix: String = "테스트 메시지",
-    ): List<Chat> =
-        (0 until count).map {
-            createPersistedChat(chatRoomId, userId, "$messagePrefix $it")
-        }
+    ): List<Chat> {
+        val chatEntities =
+            (0 until count).map {
+                ChatEntity(
+                    chatRoomId = chatRoomId,
+                    userId = userId,
+                    content = "$messagePrefix $it",
+                    chatType = ChatType.GENERAL,
+                )
+            }
+        return chatJpaRepository.saveAll(chatEntities).map { it.toDomain() }
+    }
 
     fun createPersistedRandomUserChats(
         chatRoomId: Long,
         userIds: List<String>,
         count: Int = 10,
         messagePrefix: String = "테스트 메시지",
-    ): List<Chat> =
-        (0 until count).map {
-            createPersistedChat(chatRoomId, userIds[Random.nextInt(userIds.size)], "$messagePrefix $it")
-        }
+    ): List<Chat> {
+        val chatEntities =
+            (0 until count).map {
+                ChatEntity(
+                    chatRoomId = chatRoomId,
+                    userId = userIds[Random.nextInt(userIds.size)],
+                    content = "$messagePrefix $it",
+                    chatType = ChatType.GENERAL,
+                )
+            }
+        return chatJpaRepository.saveAll(chatEntities).map { it.toDomain() }
+    }
 
     fun deleteAll() {
         chatJpaRepository.deleteAll()

--- a/api/src/test/kotlin/com/backgu/amaker/fixture/EventFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/fixture/EventFixtureFacade.kt
@@ -1,0 +1,24 @@
+package com.backgu.amaker.fixture
+
+import com.backgu.amaker.chat.domain.ChatRoom
+import org.springframework.stereotype.Component
+
+@Component
+class EventFixtureFacade(
+    val chatFixtureFacade: ChatFixtureFacade,
+) {
+    fun setUp(
+        userId: String = "test-user-id",
+        name: String = "김리더",
+        workspaceName: String = "테스트 워크스페이스",
+    ): ChatRoom =
+        chatFixtureFacade.setUp(
+            userId = userId,
+            name = name,
+            workspaceName = workspaceName,
+        )
+
+    fun deleteAll() {
+        chatFixtureFacade.deleteAll()
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -9,7 +9,6 @@ repositories {
     mavenCentral()
 }
 
-
 allOpen {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.Embeddable")

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -9,6 +9,13 @@ repositories {
     mavenCentral()
 }
 
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.MappedSuperclass")
+}
+
 dependencies {
     testImplementation(kotlin("test"))
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/Chat.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/Chat.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.chat.domain
 
+import com.backgu.amaker.event.domain.ReplyEvent
 import java.time.LocalDateTime
 
 class Chat(
@@ -10,4 +11,22 @@ class Chat(
     val chatType: ChatType,
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
-)
+) {
+    fun crateReplyEvent(
+        deadLine: LocalDateTime,
+        notificationStartHour: Int,
+        notificationStartMinute: Int,
+        notificationInterval: Int,
+        eventDetails: String,
+    ) = ReplyEvent(
+        id = id,
+        eventTitle = content,
+        deadLine = deadLine,
+        notificationStartTime =
+            deadLine
+                .minusHours(notificationStartHour.toLong())
+                .minusMinutes(notificationStartMinute.toLong()),
+        notificationInterval = notificationInterval,
+        eventDetails = eventDetails,
+    )
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/chat/domain/ChatRoom.kt
@@ -20,14 +20,14 @@ class ChatRoom(
 
     fun createChat(
         user: User,
-        chatRoom: ChatRoom,
         content: String,
+        chatType: ChatType = ChatType.GENERAL,
     ): Chat =
         Chat(
             userId = user.id,
-            chatRoomId = chatRoom.id,
+            chatRoomId = this.id,
             content = content,
-            chatType = ChatType.GENERAL,
+            chatType = chatType,
         )
 
     fun updateLastChatId(chat: Chat): ChatRoom {

--- a/domain/src/main/kotlin/com/backgu/amaker/event/domain/ReplyEvent.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/event/domain/ReplyEvent.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.event.domain
+
+import com.backgu.amaker.user.domain.User
+import java.time.LocalDateTime
+
+class ReplyEvent(
+    val id: Long,
+    val eventTitle: String,
+    val eventDetails: String,
+    val deadLine: LocalDateTime,
+    val notificationStartTime: LocalDateTime,
+    val notificationInterval: Int,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun createAssignedUsers(userIds: List<User>): List<ReplyEventAssignedUser> =
+        userIds.map { ReplyEventAssignedUser(eventId = id, userId = it.id) }
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/event/domain/ReplyEventAssignedUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/event/domain/ReplyEventAssignedUser.kt
@@ -1,0 +1,12 @@
+package com.backgu.amaker.event.domain
+
+import java.time.LocalDateTime
+
+class ReplyEventAssignedUser(
+    val id: Long = 0L,
+    val eventId: Long,
+    val userId: String,
+    val isFinished: Boolean = false,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/domain/src/main/kotlin/com/backgu/amaker/event/jpa/EventEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/event/jpa/EventEntity.kt
@@ -1,0 +1,27 @@
+package com.backgu.amaker.event.jpa
+
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorColumn
+import jakarta.persistence.DiscriminatorType
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
+import java.time.LocalDateTime
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "event_type", discriminatorType = DiscriminatorType.STRING)
+abstract class EventEntity(
+    @Id
+    val id: Long,
+    @Column(nullable = false)
+    val eventTitle: String,
+    @Column(nullable = false)
+    val deadLine: LocalDateTime,
+    @Column(nullable = false)
+    val notificationStartTime: LocalDateTime,
+    @Column(nullable = false)
+    val notificationInterval: Int,
+) : BaseTimeEntity()

--- a/domain/src/main/kotlin/com/backgu/amaker/event/jpa/ReplyEventAssignedUserEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/event/jpa/ReplyEventAssignedUserEntity.kt
@@ -1,0 +1,41 @@
+package com.backgu.amaker.event.jpa
+
+import com.backgu.amaker.common.jpa.BaseTimeEntity
+import com.backgu.amaker.event.domain.ReplyEventAssignedUser
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class ReplyEventAssignedUserEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    val eventId: Long,
+    @Column(nullable = false)
+    val userId: String,
+    @Column(nullable = false)
+    val isFinished: Boolean = false,
+) : BaseTimeEntity() {
+    fun toDomain(): ReplyEventAssignedUser =
+        ReplyEventAssignedUser(
+            id = id,
+            eventId = eventId,
+            userId = userId,
+            isFinished = isFinished,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    companion object {
+        fun of(replyEventAssigned: ReplyEventAssignedUser): ReplyEventAssignedUserEntity =
+            ReplyEventAssignedUserEntity(
+                id = replyEventAssigned.id,
+                eventId = replyEventAssigned.eventId,
+                userId = replyEventAssigned.userId,
+            )
+    }
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/event/jpa/ReplyEventEntity.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/event/jpa/ReplyEventEntity.kt
@@ -1,0 +1,49 @@
+package com.backgu.amaker.event.jpa
+
+import com.backgu.amaker.event.domain.ReplyEvent
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import java.time.LocalDateTime
+
+@Entity
+@DiscriminatorValue(value = "REPLY")
+class ReplyEventEntity(
+    @Column(nullable = false)
+    val eventDetails: String,
+    id: Long,
+    eventTitle: String,
+    deadLine: LocalDateTime,
+    notificationStartTime: LocalDateTime,
+    notificationInterval: Int,
+) : EventEntity(
+        id = id,
+        eventTitle = eventTitle,
+        deadLine = deadLine,
+        notificationStartTime = notificationStartTime,
+        notificationInterval = notificationInterval,
+    ) {
+    fun toDomain() =
+        ReplyEvent(
+            id = id,
+            eventTitle = eventTitle,
+            eventDetails = eventDetails,
+            deadLine = deadLine,
+            notificationStartTime = notificationStartTime,
+            notificationInterval = notificationInterval,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    companion object {
+        fun of(replyEvent: ReplyEvent) =
+            ReplyEventEntity(
+                id = replyEvent.id,
+                eventTitle = replyEvent.eventTitle,
+                eventDetails = replyEvent.eventDetails,
+                deadLine = replyEvent.deadLine,
+                notificationStartTime = replyEvent.notificationStartTime,
+                notificationInterval = replyEvent.notificationInterval,
+            )
+    }
+}

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatRoomTest.kt
@@ -34,7 +34,7 @@ class ChatRoomTest {
         val content = "안녕하세요"
 
         // when
-        val chat: Chat = chatRoom.createChat(user = user, chatRoom = chatRoom, content = content)
+        val chat: Chat = chatRoom.createChat(user = user, content = content)
 
         // then
         assertThat(chat.chatType).isEqualTo(ChatType.GENERAL)

--- a/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/chat/domain/ChatTest.kt
@@ -1,0 +1,44 @@
+package com.backgu.amaker.chat.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import java.time.LocalDateTime
+import kotlin.test.Test
+
+@DisplayName("Chat 테스트")
+class ChatTest {
+    @Test
+    @DisplayName("reply 이벤트 생성 테스트")
+    fun creatReplyEvent() {
+        // given
+        val chat =
+            Chat(
+                id = 1,
+                userId = "user1",
+                chatRoomId = 1,
+                content = "안녕하세요",
+                chatType = ChatType.GENERAL,
+            )
+        val deadLine = LocalDateTime.now().plusDays(1)
+        val notificationStartHour = 1
+        val notificationStartMinute = 30
+
+        // when
+
+        val replyEvent =
+            chat.crateReplyEvent(
+                deadLine = deadLine,
+                notificationStartHour = notificationStartHour,
+                notificationStartMinute = notificationStartMinute,
+                notificationInterval = 10,
+                eventDetails = "이벤트 상세 내용",
+            )
+
+        // then
+        assertThat(replyEvent.eventTitle).isEqualTo(chat.content)
+        assertThat(replyEvent.deadLine).isEqualTo(deadLine)
+        assertThat(replyEvent.notificationStartTime).isEqualTo(
+            deadLine.minusHours(notificationStartHour.toLong()).minusMinutes(notificationStartMinute.toLong()),
+        )
+    }
+}


### PR DESCRIPTION
# Why
리플라이 이벤트 생성 API 구현함
기존에 도메인이 전혀 없었기 때문에 생각보다 시간이 더 걸렸다

# How
먼저 채팅을 생성하고 채팅의 id를 활용하여
reply 이벤트를 생성하게 만들었다

> 채팅 도메인에서  reply 이벤트를 생성

`EventEntity` 를 `ReplyEventEntity`가 상속하는 형태로 만들고
Join Table 전략을 사용함 -> ERD 형태에 맞게 하기 위해

# Result
```kotlin
@Entity
@Inheritance(strategy = InheritanceType.JOINED)
@DiscriminatorColumn(name = "event_type", discriminatorType = DiscriminatorType.STRING)
abstract class EventEntity(
    @Id
    val id: Long,
    @Column(nullable = false)
    val eventTitle: String,
    @Column(nullable = false)
    val deadLine: LocalDateTime,
    @Column(nullable = false)
    val notificationStartTime: LocalDateTime,
    @Column(nullable = false)
    val notificationInterval: Int,
) : BaseTimeEntity()

@Entity
@DiscriminatorValue(value = "REPLY")
class ReplyEventEntity(
    @Column(nullable = false)
    val eventDetails: String,
    id: Long,
    eventTitle: String,
    deadLine: LocalDateTime,
    notificationStartTime: LocalDateTime,
    notificationInterval: Int,
) : EventEntity(
        id = id,
        eventTitle = eventTitle,
        deadLine = deadLine,
        notificationStartTime = notificationStartTime,
        notificationInterval = notificationInterval,
    )
```
# Prize
상속 과정에서 kotlin 객체의 final 문제를 해결하기 위해
`jpa annotation` 의 allOpen 설정을 추가해줌

# Link
BG-239