### PR TITLE
[BG-259]: 사진 등록 채팅 API를 개발한다 (1h / 5h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatController.kt
@@ -13,6 +13,7 @@ import com.backgu.amaker.api.common.infra.ApiHandler
 import com.backgu.amaker.api.security.JwtAuthentication
 import com.backgu.amaker.domain.chat.ChatType
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
@@ -120,16 +121,8 @@ class ChatController(
         @PathVariable("chat-room-id") chatRoomId: Long,
         @Valid @RequestBody fileChatCreateRequest: FileChatCreateRequest,
     ): ResponseEntity<Unit> {
-        val chatWithUserDto =
-            chatFacadeService.createChat(fileChatCreateRequest.toDto(), token.id, chatRoomId, ChatType.FILE)
-        return ResponseEntity
-            .created(
-                ServletUriComponentsBuilder
-                    .fromCurrentRequest()
-                    .path("/{id}")
-                    .buildAndExpand(chatWithUserDto.id)
-                    .toUri(),
-            ).build()
+        chatFacadeService.createChat(fileChatCreateRequest.toDto(), token.id, chatRoomId, ChatType.FILE)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
     }
 
     @PostMapping("/chat-rooms/{chat-room-id}/chats/img")
@@ -138,15 +131,7 @@ class ChatController(
         @PathVariable("chat-room-id") chatRoomId: Long,
         @Valid @RequestBody fileChatCreateRequest: FileChatCreateRequest,
     ): ResponseEntity<Unit> {
-        val chatWithUserDto =
-            chatFacadeService.createChat(fileChatCreateRequest.toDto(), token.id, chatRoomId, ChatType.IMAGE)
-        return ResponseEntity
-            .created(
-                ServletUriComponentsBuilder
-                    .fromCurrentRequest()
-                    .path("/{id}")
-                    .buildAndExpand(chatWithUserDto.id)
-                    .toUri(),
-            ).build()
+        chatFacadeService.createChat(fileChatCreateRequest.toDto(), token.id, chatRoomId, ChatType.IMAGE)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatController.kt
@@ -120,8 +120,26 @@ class ChatController(
         @PathVariable("chat-room-id") chatRoomId: Long,
         @Valid @RequestBody fileChatCreateRequest: FileChatCreateRequest,
     ): ResponseEntity<Unit> {
-        val chatWithUserDto: DefaultChatWithUserDto =
+        val chatWithUserDto =
             chatFacadeService.createChat(fileChatCreateRequest.toDto(), token.id, chatRoomId, ChatType.FILE)
+        return ResponseEntity
+            .created(
+                ServletUriComponentsBuilder
+                    .fromCurrentRequest()
+                    .path("/{id}")
+                    .buildAndExpand(chatWithUserDto.id)
+                    .toUri(),
+            ).build()
+    }
+
+    @PostMapping("/chat-rooms/{chat-room-id}/chats/img")
+    override fun createChatWithImage(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("chat-room-id") chatRoomId: Long,
+        @Valid @RequestBody fileChatCreateRequest: FileChatCreateRequest,
+    ): ResponseEntity<Unit> {
+        val chatWithUserDto =
+            chatFacadeService.createChat(fileChatCreateRequest.toDto(), token.id, chatRoomId, ChatType.IMAGE)
         return ResponseEntity
             .created(
                 ServletUriComponentsBuilder

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatSwagger.kt
@@ -94,4 +94,19 @@ interface ChatSwagger {
         @PathVariable("chat-room-id") chatRoomId: Long,
         @Valid @RequestBody fileChatCreateRequest: FileChatCreateRequest,
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "사진 채팅 생성", description = "사진 채팅을 생성합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "사진 채팅 생성 성공",
+            ),
+        ],
+    )
+    fun createChatWithImage(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("chat-room-id") chatRoomId: Long,
+        @Valid @RequestBody fileChatCreateRequest: FileChatCreateRequest,
+    ): ResponseEntity<Unit>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/ChatWithUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/ChatWithUserResponse.kt
@@ -19,7 +19,7 @@ interface ChatWithUserResponse<T> {
     @get:Schema(description = "채팅 내용", example = "안녕하세요")
     var content: T
 
-    @get:Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK)", example = "GENERAL")
+    @get:Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK, IMAGE)", example = "GENERAL")
     val chatType: ChatType
 
     @get:Schema(description = "생성일시", example = "2021-05-29T00:00:00")

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/DefaultChatWithUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/DefaultChatWithUserResponse.kt
@@ -14,7 +14,7 @@ data class DefaultChatWithUserResponse(
     override val chatRoomId: Long,
     @Schema(description = "채팅 내용", example = "안녕하세요")
     override var content: String,
-    @Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK, FILE)", example = "GENERAL")
+    @Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK, FILE, IMAGE)", example = "GENERAL")
     override val chatType: ChatType,
     @Schema(description = "생성일시", example = "2021-05-29T00:00:00")
     override val createdAt: LocalDateTime,
@@ -24,7 +24,7 @@ data class DefaultChatWithUserResponse(
     companion object {
         fun of(chatWithUserDto: ChatWithUserDto<*>): ChatWithUserResponse<*> =
             when (chatWithUserDto.chatType) {
-                ChatType.FILE -> FileChatWithUserResponse.of(chatWithUserDto)
+                ChatType.FILE, ChatType.IMAGE -> FileChatWithUserResponse.of(chatWithUserDto)
                 else ->
                     DefaultChatWithUserResponse(
                         id = chatWithUserDto.id,

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/EventChatWithUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/EventChatWithUserResponse.kt
@@ -15,7 +15,7 @@ data class EventChatWithUserResponse(
     override val chatRoomId: Long,
     @Schema(description = "채팅 내용", example = "안녕하세요")
     override var content: EventWithUserResponse,
-    @Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK, FILE)", example = "GENERAL")
+    @Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK, FILE, IMAGE)", example = "GENERAL")
     override val chatType: ChatType,
     @Schema(description = "생성일시", example = "2021-05-29T00:00:00")
     override val createdAt: LocalDateTime,

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/FileChatWithUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/FileChatWithUserResponse.kt
@@ -15,7 +15,7 @@ data class FileChatWithUserResponse(
     override val chatRoomId: Long,
     @Schema(description = "채팅 내용", example = "안녕하세요")
     override var content: FileResponse,
-    @Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK, FILE)", example = "GENERAL")
+    @Schema(description = "채팅 타입(GENERAL, REPLY, REACTION, TASK, FILE, IMAGE)", example = "GENERAL")
     override val chatType: ChatType,
     @Schema(description = "생성일시", example = "2021-05-29T00:00:00")
     override val createdAt: LocalDateTime,

--- a/api/src/main/kotlin/com/backgu/amaker/api/common/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/common/exception/GlobalExceptionHandler.kt
@@ -6,6 +6,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.support.DefaultMessageSourceResolvable
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -31,6 +32,15 @@ class GlobalExceptionHandler(
             .badRequest()
             .body(apiHandler.onFailure(StatusCode.INVALID_INPUT_VALUE, errorMap))
     }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(
+        e: HttpMessageNotReadableException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ApiError<Unit>> =
+        ResponseEntity
+            .badRequest()
+            .body(apiHandler.onFailure(StatusCode.INVALID_INPUT_VALUE))
 
     @ExceptionHandler(HandlerMethodValidationException::class)
     fun handleHandlerMethodValidationException(

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/chat/ChatType.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/chat/ChatType.kt
@@ -6,6 +6,7 @@ enum class ChatType {
     REPLY,
     REACTION,
     FILE,
+    IMAGE,
     ;
 
     companion object {


### PR DESCRIPTION
# Why

* 기존에 했던 파일 채팅 api와 구조가 같아서 빨리 끝났다.

# How

* 기존에는 리다이렉트되는 url을 다 적어줬는데 이 부분을 다 뺏다.
* 이 서비스에는 채팅 아이디로 단건 조회하는 API가 존재하지 않기 때문에

```kotlin
@PostMapping("/chat-rooms/{chat-room-id}/chats/img")
override fun createChatWithImage(
    @AuthenticationPrincipal token: JwtAuthentication,
    @PathVariable("chat-room-id") chatRoomId: Long,
    @Valid @RequestBody fileChatCreateRequest: FileChatCreateRequest,
): ResponseEntity<Unit> {
    chatFacadeService.createChat(fileChatCreateRequest.toDto(), token.id, chatRoomId, ChatType.IMAGE)
    return ResponseEntity.status(HttpStatus.CREATED).build()
}
```

# Result
![스크린샷 2024-07-28 오후 6 07 46](https://github.com/user-attachments/assets/772ca2d5-6caf-43bd-bc3e-1fabb25a3382)

# Link

BG-259