### PR TITLE
[BG-294]: 정순 채팅 커서 이슈 (0.2h / 2h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/controller/ChatController.kt
@@ -70,7 +70,7 @@ class ChatController(
     ): ResponseEntity<ApiResult<ChatListResponse>> =
         ResponseEntity.ok().body(
             apiHandler.onSuccess(
-                ChatListResponse.of(
+                ChatListResponse.previousOf(
                     chatFacadeService.getPreviousChat(
                         token.id,
                         chatQueryRequest.toDto(chatRoomId),
@@ -87,7 +87,7 @@ class ChatController(
     ): ResponseEntity<ApiResult<ChatListResponse>> =
         ResponseEntity.ok().body(
             apiHandler.onSuccess(
-                ChatListResponse.of(
+                ChatListResponse.afterOf(
                     chatFacadeService.getAfterChat(
                         token.id,
                         chatQueryRequest.toDto(chatRoomId),

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/ChatListResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/ChatListResponse.kt
@@ -15,13 +15,22 @@ class ChatListResponse(
     val nextCursor: Long,
 ) {
     companion object {
-        fun of(chatListDto: ChatListDto) =
+        fun previousOf(chatListDto: ChatListDto) =
             ChatListResponse(
                 chatRoomId = chatListDto.chatRoomId,
                 cursor = chatListDto.cursor,
                 size = chatListDto.size,
                 chatList = chatListDto.chatList.map { ChatWithUserResponse.of(it) },
                 nextCursor = chatListDto.chatList.first().id,
+            )
+
+        fun afterOf(chatListDto: ChatListDto) =
+            ChatListResponse(
+                chatRoomId = chatListDto.chatRoomId,
+                cursor = chatListDto.cursor,
+                size = chatListDto.size,
+                chatList = chatListDto.chatList.map { ChatWithUserResponse.of(it) },
+                nextCursor = chatListDto.chatList.last().id,
             )
     }
 }


### PR DESCRIPTION
# Why

* 응답에서 다음 커서를 정해주는 부분에서, 정순으로 조회하던, 역순으로 조회하던 역순의 다음커서가 조회되는 이슈가 있었다.

# How

```kotlin
class ChatListResponse(
    @Schema(description = "채팅방 ID", example = "1")
    val chatRoomId: Long,
    @Schema(description = "채팅 커서", example = "101")
    val cursor: Long,
    @Schema(description = "읽어올 채팅의 개수", example = "100", defaultValue = "20")
    val size: Int,
    val chatList: List<ChatWithUserResponse<*>>,
    @Schema(description = "다음 요청에 대한 커서", example = "100", defaultValue = "121")
    val nextCursor: Long,
) {
    companion object {
        fun previousOf(chatListDto: ChatListDto) =
            ChatListResponse(
                chatRoomId = chatListDto.chatRoomId,
                cursor = chatListDto.cursor,
                size = chatListDto.size,
                chatList = chatListDto.chatList.map { ChatWithUserResponse.of(it) },
                nextCursor = chatListDto.chatList.first().id,
            )

        fun afterOf(chatListDto: ChatListDto) =
            ChatListResponse(
                chatRoomId = chatListDto.chatRoomId,
                cursor = chatListDto.cursor,
                size = chatListDto.size,
                chatList = chatListDto.chatList.map { ChatWithUserResponse.of(it) },
                nextCursor = chatListDto.chatList.last().id,
            )
    }
}
```

* 두 가지로 나눠서 호출하도록 수정해줬다.

# Result

* 정순 조회

![스크린샷 2024-07-28 오후 6 22 43](https://github.com/user-attachments/assets/ccc7b8fb-a70d-49bf-876d-fde2b26a3ff3)


* 역순 조
![스크린샷 2024-07-28 오후 6 22 31](https://github.com/user-attachments/assets/3c349322-04b1-4c89-a4aa-fc9325c4d071)
회

# Link

BG-294