### PR TITLE
[BG-305]: 리플라이 이벤트 응답 조회 API 개발 (3h / 2h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/api/common/dto/response/PageResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/common/dto/response/PageResponse.kt
@@ -1,0 +1,32 @@
+package com.backgu.amaker.api.common.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+interface PageResponse<T> {
+    @get:Schema(description = "요소 리스트")
+    val content: List<T>
+
+    @get:Schema(description = "페이지 번호", example = "0")
+    val pageNumber: Int
+
+    @get:Schema(description = "페이지 사이즈", example = "10", defaultValue = "20")
+    val pageSize: Int
+
+    @get:Schema(description = "총 요소 수", example = "25")
+    val totalElements: Long
+
+    @get:Schema(description = "총 페이지 수", example = "3")
+    val totalPages: Int
+
+    @get:Schema(description = "다음 페이지 존재 유무", example = "true")
+    val hasNext: Boolean
+
+    @get:Schema(description = "이전 페이지 존재 유무", example = "false")
+    val hasPrevious: Boolean
+
+    @get:Schema(description = "첫 페이지인지", example = "true")
+    val isFirst: Boolean
+
+    @get:Schema(description = "마지막 페이지인지", example = "false")
+    val isLast: Boolean
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentController.kt
@@ -1,12 +1,22 @@
 package com.backgu.amaker.api.event.controller
 
+import com.backgu.amaker.api.common.dto.response.ApiResult
+import com.backgu.amaker.api.common.dto.response.PageResponse
+import com.backgu.amaker.api.common.infra.ApiHandler
+import com.backgu.amaker.api.event.dto.query.ReplyQueryRequest
 import com.backgu.amaker.api.event.dto.request.ReplyCommentCreateRequest
+import com.backgu.amaker.api.event.dto.response.ReplyCommentWithUserResponse
+import com.backgu.amaker.api.event.dto.response.ReplyCommentsViewResponse
 import com.backgu.amaker.api.event.service.EventCommentFacadeService
 import com.backgu.amaker.api.security.JwtAuthentication
 import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -17,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1")
 class EventCommentController(
     private val eventCommentFacadeService: EventCommentFacadeService,
+    private val apiHandler: ApiHandler,
 ) : EventCommentSwagger {
     @PostMapping("/events/{event-id}/reply/comments")
     override fun createReplyComment(
@@ -26,5 +37,30 @@ class EventCommentController(
     ): ResponseEntity<Unit> {
         eventCommentFacadeService.createReplyComment(token.id, eventId, replyCommentCreateRequest.toDto())
         return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping("/events/{event-id}/reply/comments")
+    override fun findReplyComments(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("event-id") eventId: Long,
+        @ModelAttribute replyQueryRequest: ReplyQueryRequest,
+    ): ResponseEntity<ApiResult<PageResponse<ReplyCommentWithUserResponse>>> {
+        val pageable =
+            PageRequest.of(
+                replyQueryRequest.page,
+                replyQueryRequest.size,
+                Sort.by("id").ascending(),
+            )
+        return ResponseEntity.ok(
+            apiHandler.onSuccess(
+                ReplyCommentsViewResponse.of(
+                    eventCommentFacadeService.findReplyComments(
+                        token.id,
+                        eventId,
+                        pageable,
+                    ),
+                ),
+            ),
+        )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentSwagger.kt
@@ -1,6 +1,11 @@
 package com.backgu.amaker.api.event.controller
 
+import com.backgu.amaker.api.common.dto.response.ApiResult
+import com.backgu.amaker.api.common.dto.response.PageResponse
+import com.backgu.amaker.api.event.dto.query.ReplyQueryRequest
 import com.backgu.amaker.api.event.dto.request.ReplyCommentCreateRequest
+import com.backgu.amaker.api.event.dto.response.ReplyCommentWithUserResponse
+import com.backgu.amaker.api.event.dto.response.ReplyCommentsViewResponse
 import com.backgu.amaker.api.security.JwtAuthentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -24,4 +29,19 @@ interface EventCommentSwagger {
         eventId: Long,
         replyCommentCreateRequest: ReplyCommentCreateRequest,
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "reply 이벤트 응답 조회", description = "reply 이벤트 응답 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "reply 이벤트 응답 조회 성공",
+            ),
+        ],
+    )
+    fun findReplyComments(
+        token: JwtAuthentication,
+        eventId: Long,
+        replyQueryRequest: ReplyQueryRequest,
+    ): ResponseEntity<ApiResult<PageResponse<ReplyCommentWithUserResponse>>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentSwagger.kt
@@ -5,7 +5,6 @@ import com.backgu.amaker.api.common.dto.response.PageResponse
 import com.backgu.amaker.api.event.dto.query.ReplyQueryRequest
 import com.backgu.amaker.api.event.dto.request.ReplyCommentCreateRequest
 import com.backgu.amaker.api.event.dto.response.ReplyCommentWithUserResponse
-import com.backgu.amaker.api.event.dto.response.ReplyCommentsViewResponse
 import com.backgu.amaker.api.security.JwtAuthentication
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReplyCommentDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReplyCommentDto.kt
@@ -3,7 +3,7 @@ package com.backgu.amaker.api.event.dto
 import com.backgu.amaker.domain.event.ReplyComment
 import java.time.LocalDateTime
 
-class ReplyCommentDto(
+data class ReplyCommentDto(
     val id: Long,
     val userId: String,
     val eventId: Long,

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReplyCommentWithUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReplyCommentWithUserDto.kt
@@ -1,0 +1,31 @@
+package com.backgu.amaker.api.event.dto
+
+import com.backgu.amaker.api.user.dto.UserDto
+import com.backgu.amaker.domain.event.ReplyComment
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+data class ReplyCommentWithUserDto(
+    val id: Long,
+    val userId: String,
+    val eventId: Long,
+    val content: String,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+    val userDto: UserDto,
+) {
+    companion object {
+        fun of(
+            replyComment: ReplyComment,
+            user: User,
+        ) = ReplyCommentWithUserDto(
+            id = replyComment.id,
+            userId = replyComment.userId,
+            eventId = replyComment.eventId,
+            content = replyComment.content,
+            createdAt = replyComment.createdAt,
+            updatedAt = replyComment.updatedAt,
+            userDto = UserDto.of(user),
+        )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReplyQuery.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReplyQuery.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.api.event.dto
+
+data class ReplyQuery(
+    val eventId: Long,
+    val size: Int,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/query/ReplyQueryRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/query/ReplyQueryRequest.kt
@@ -1,0 +1,17 @@
+package com.backgu.amaker.api.event.dto.query
+
+import com.backgu.amaker.api.event.dto.ReplyQuery
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ReplyQueryRequest(
+    @Schema(description = "읽어올 페이지 번호", example = "2", defaultValue = "0")
+    val page: Int = 0,
+    @Schema(description = "읽어올 응답의 개수", example = "100", defaultValue = "20")
+    val size: Int = 20,
+) {
+    fun toDto(eventId: Long): ReplyQuery =
+        ReplyQuery(
+            eventId = eventId,
+            size = size,
+        )
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/EventWithUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/EventWithUserResponse.kt
@@ -4,7 +4,7 @@ import com.backgu.amaker.api.event.dto.EventWithUserDto
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
-class EventWithUserResponse(
+data class EventWithUserResponse(
     @Schema(
         description = "이벤트 제목",
         example = "우리 어디서 만날지",

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/ReplyCommentWithUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/ReplyCommentWithUserResponse.kt
@@ -1,0 +1,36 @@
+package com.backgu.amaker.api.event.dto.response
+
+import com.backgu.amaker.api.event.dto.ReplyCommentWithUserDto
+import com.backgu.amaker.api.user.dto.response.UserResponse
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class ReplyCommentWithUserResponse(
+    @Schema(description = "리플라이 응답 id", example = "1")
+    val id: Long,
+    @Schema(description = "유저 id", example = "2")
+    val userId: String,
+    @Schema(description = "이벤트 id", example = "2")
+    val eventId: Long,
+    @Schema(description = "응답 내용", example = "좋네용!")
+    val content: String,
+    @Schema(description = "생성 시간", example = "2024-07-02T19:56:05.624+09:00")
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    @Schema(description = "수정 시간", example = "2024-07-02T19:56:05.624+09:00")
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+    @Schema(description = "유저 응답")
+    val userResponse: UserResponse,
+) {
+    companion object {
+        fun of(replyCommentWithUserDto: ReplyCommentWithUserDto) =
+            ReplyCommentWithUserResponse(
+                id = replyCommentWithUserDto.id,
+                userId = replyCommentWithUserDto.userId,
+                eventId = replyCommentWithUserDto.eventId,
+                content = replyCommentWithUserDto.content,
+                createdAt = replyCommentWithUserDto.createdAt,
+                updatedAt = replyCommentWithUserDto.updatedAt,
+                userResponse = UserResponse.of(replyCommentWithUserDto.userDto),
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/ReplyCommentsViewResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/ReplyCommentsViewResponse.kt
@@ -1,0 +1,34 @@
+package com.backgu.amaker.api.event.dto.response
+
+import com.backgu.amaker.api.common.dto.response.PageResponse
+import com.backgu.amaker.api.event.dto.ReplyCommentWithUserDto
+import org.springframework.data.domain.Page
+
+data class ReplyCommentsViewResponse(
+    override val content: List<ReplyCommentWithUserResponse>,
+    override val pageNumber: Int,
+    override val pageSize: Int,
+    override val totalElements: Long,
+    override val totalPages: Int,
+    override val hasNext: Boolean,
+    override val hasPrevious: Boolean,
+    override val isFirst: Boolean,
+    override val isLast: Boolean,
+) : PageResponse<ReplyCommentWithUserResponse> {
+    companion object {
+        fun of(replyComments: Page<ReplyCommentWithUserDto>): PageResponse<ReplyCommentWithUserResponse> {
+            val content = replyComments.content.map { ReplyCommentWithUserResponse.of(it) }
+            return ReplyCommentsViewResponse(
+                content = content,
+                pageNumber = replyComments.number,
+                pageSize = replyComments.size,
+                totalElements = replyComments.totalElements,
+                totalPages = replyComments.totalPages,
+                hasNext = replyComments.hasNext(),
+                hasPrevious = replyComments.hasPrevious(),
+                isFirst = replyComments.isFirst,
+                isLast = replyComments.isLast,
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/service/EventCommentFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/service/EventCommentFacadeService.kt
@@ -1,11 +1,14 @@
 package com.backgu.amaker.api.event.service
 
+import com.backgu.amaker.api.chat.service.ChatRoomService
+import com.backgu.amaker.api.chat.service.ChatService
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.event.dto.ReplyCommentCreateDto
 import com.backgu.amaker.api.event.dto.ReplyCommentDto
 import com.backgu.amaker.api.event.dto.ReplyCommentWithUserDto
 import com.backgu.amaker.api.user.service.UserService
+import com.backgu.amaker.api.workspace.service.WorkspaceUserService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -18,6 +21,9 @@ class EventCommentFacadeService(
     private val replyEventService: ReplyEventService,
     private val eventAssignedUserService: EventAssignedUserService,
     private val replyCommentService: ReplyCommentService,
+    private val chatService: ChatService,
+    private val chatRoomService: ChatRoomService,
+    private val workspaceUserService: WorkspaceUserService,
 ) {
     @Transactional
     fun createReplyComment(
@@ -42,6 +48,8 @@ class EventCommentFacadeService(
         eventId: Long,
         pageable: Pageable,
     ): Page<ReplyCommentWithUserDto> {
+        workspaceUserService.validByUserIdAndChatIdInWorkspace(userId, eventId)
+
         val replyComments = replyCommentService.findAllByEventId(eventId, pageable)
 
         val userMap = userService.findAllByUserIdsToMap(replyComments.map { it.userId }.toList())

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/service/ReplyCommentService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/service/ReplyCommentService.kt
@@ -3,6 +3,8 @@ package com.backgu.amaker.api.event.service
 import com.backgu.amaker.domain.event.ReplyComment
 import com.backgu.amaker.infra.jpa.event.entity.ReplyCommentEntity
 import com.backgu.amaker.infra.jpa.event.repository.ReplyCommentRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,4 +15,9 @@ class ReplyCommentService(
 ) {
     @Transactional
     fun save(replyComment: ReplyComment): ReplyComment = replyCommentRepository.save(ReplyCommentEntity.of(replyComment)).toDomain()
+
+    fun findAllByEventId(
+        eventId: Long,
+        pageable: Pageable,
+    ): Page<ReplyComment> = replyCommentRepository.findAllByEventId(eventId, pageable).map { it.toDomain() }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceUserService.kt
@@ -54,4 +54,13 @@ class WorkspaceUserService(
         val workspaceUser = getWorkspaceUser(workspace, user)
         if (!workspaceUser.isAdmin()) throw BusinessException(StatusCode.WORKSPACE_UNAUTHORIZED)
     }
+
+    fun validByUserIdAndChatIdInWorkspace(
+        userId: String,
+        chatId: Long,
+    ) {
+        if (!workspaceUserRepository.existsByUserIdAndChatIdInWorkspace(userId, chatId)) {
+            throw BusinessException(StatusCode.WORKSPACE_UNREACHABLE)
+        }
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReplyCommentFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReplyCommentFixture.kt
@@ -22,4 +22,20 @@ class ReplyCommentFixture(
                     content = content,
                 ),
             ).toDomain()
+
+    fun createPersistedReplyComments(
+        userId: String,
+        eventId: Long,
+        count: Int = 100,
+    ): List<ReplyComment> {
+        val replyCommentEntities =
+            (0 until count).map {
+                ReplyCommentEntity(
+                    eventId = eventId,
+                    userId = userId,
+                    content = "content $it",
+                )
+            }
+        return replyCommentRepository.saveAll(replyCommentEntities).map { it.toDomain() }
+    }
 }

--- a/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReplyCommentFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReplyCommentFixtureFacade.kt
@@ -13,13 +13,18 @@ class ReplyCommentFixtureFacade(
     val chatFixture: ChatFixture,
     val eventAssignedUserFixture: EventAssignedUserFixture,
     val userFixture: UserFixture,
+    private val workspaceFixture: WorkspaceFixture,
+    private val workspaceUserFixture: WorkspaceUserFixture,
 ) {
     fun setUp(
         userId: String = "test-user-id",
         name: String = "김리더",
+        workspaceId: Long = 1L,
     ): ReplyEvent {
+        val workspace = workspaceFixture.createPersistedWorkspace(workspaceId, "test-workspace")
+        workspaceUserFixture.createPersistedWorkspaceUser(workspace.id, userId)
         val user = userFixture.createPersistedUser(id = userId, name = name)
-        val chatRoom = chatRoomFixture.createPersistedChatRoom(1, ChatRoomType.DEFAULT)
+        val chatRoom = chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         val chat = chatFixture.createPersistedChat(chatRoom.id, userId, chatType = ChatType.REPLY)
         val replyEvent = replyEventFixture.createPersistedReplyEvent(chat.id)
         val eventAssignedUser = eventAssignedUserFixture.createPersistedEventAssignedUser(userId, replyEvent.id)

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReplyCommentRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReplyCommentRepository.kt
@@ -1,6 +1,13 @@
 package com.backgu.amaker.infra.jpa.event.repository
 
 import com.backgu.amaker.infra.jpa.event.entity.ReplyCommentEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ReplyCommentRepository : JpaRepository<ReplyCommentEntity, Long>
+interface ReplyCommentRepository : JpaRepository<ReplyCommentEntity, Long> {
+    fun findAllByEventId(
+        eventId: Long,
+        pageable: Pageable,
+    ): Page<ReplyCommentEntity>
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/workspace/repository/WorkspaceUserRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/workspace/repository/WorkspaceUserRepository.kt
@@ -23,4 +23,16 @@ interface WorkspaceUserRepository : JpaRepository<WorkspaceUserEntity, Long> {
         userId: String,
         workspaceId: Long,
     ): WorkspaceUserEntity?
+
+    @Query(
+        "select case when count(c)> 0 then true else false end " +
+            "from Chat c " +
+            "inner join ChatRoom ch on ch.id = c.chatRoomId " +
+            "inner join WorkspaceUser wu on wu.workspaceId = ch.workspaceId " +
+            "where wu.userId = :userId and c.id = :chatId",
+    )
+    fun existsByUserIdAndChatIdInWorkspace(
+        userId: String,
+        chatId: Long,
+    ): Boolean
 }


### PR DESCRIPTION
# Why
페이지로 응답을 주는 경우가 처음이어서
인터페이스등을 만들때 시간이 꽤 걸림

추가적으로 워크스페이스에 참여하지 않은 유저는 조회를 못하게 함

# How
기본으로 20개를 받아오소 id를 기반으로 오름차순으로 데이터를 준다

# Result
![image](https://github.com/user-attachments/assets/585e7557-f5ce-4e87-a101-54c8ba331b77)

![image](https://github.com/user-attachments/assets/1c0ebb6c-3371-4086-aa4a-3f260d41731f)

# Link
BG-305