### PR TITLE
[BG-306]: 리플라이 채팅 응답 대기 인원 표시 기능 추가 (0.5h / 2h)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 .Ds_Store
 
+.run

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/service/ChatFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/service/ChatFacadeService.kt
@@ -101,7 +101,10 @@ class ChatFacadeService(
         val userMap = userService.findAllByUserIdsToMap(eventAssignedUsers.map { it.userId })
         val eventUsers = eventAssignedUsers.mapNotNull { userMap[it.userId] }
 
-        return EventChatWithUserDto.of(chat, EventWithUserDto.of(event, eventUsers))
+        return EventChatWithUserDto.of(
+            chat,
+            EventWithUserDto.of(event, eventUsers, eventAssignedUsers.count { it.isFinished }),
+        )
     }
 
     private fun markMostRecentChatAsRead(
@@ -123,7 +126,8 @@ class ChatFacadeService(
         if (ChatType.isEventChat(chat.chatType)) {
             val event = eventMap[chat.id] ?: throw BusinessException(StatusCode.EVENT_NOT_FOUND)
             val eventUsers = eventUserMap[event.id]?.mapNotNull { userMap[it.userId] } ?: emptyList()
-            EventChatWithUserDto.of(chat, EventWithUserDto.of(event, eventUsers))
+            val finishedNumber = eventUserMap[event.id]?.count { it.isFinished } ?: 0
+            EventChatWithUserDto.of(chat, EventWithUserDto.of(event, eventUsers, finishedNumber))
         } else {
             chat
         }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/EventWithUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/EventWithUserDto.kt
@@ -12,11 +12,14 @@ data class EventWithUserDto(
     val notificationStartTime: LocalDateTime,
     val notificationInterval: Int,
     val users: List<UserDto>,
+    val finishedCount: Int,
+    val totalAssignedCount: Int,
 ) {
     companion object {
         fun of(
             event: Event,
             users: List<User>,
+            finishedCount: Int,
         ): EventWithUserDto =
             EventWithUserDto(
                 id = event.id,
@@ -25,6 +28,8 @@ data class EventWithUserDto(
                 notificationStartTime = event.notificationStartTime,
                 notificationInterval = event.notificationInterval,
                 users = users.map { UserDto.of(it) },
+                finishedCount = finishedCount,
+                totalAssignedCount = users.size,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/EventWithUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/response/EventWithUserResponse.kt
@@ -30,6 +30,16 @@ data class EventWithUserResponse(
         example = "[\"http://a-maker.com/hi1.png\", \"http://a-maker.com/hi2.png\"]",
     )
     val users: List<String>,
+    @Schema(
+        description = "완료된 이벤트 수",
+        example = "2",
+    )
+    val finishedCount: Int,
+    @Schema(
+        description = "총 배정된 이벤트 수",
+        example = "5",
+    )
+    val totalAssignedCount: Int,
 ) {
     companion object {
         fun of(event: EventWithUserDto) =
@@ -39,6 +49,8 @@ data class EventWithUserResponse(
                 notificationStartTime = event.notificationStartTime,
                 notificationInterval = event.notificationInterval,
                 users = event.users.map { it.picture },
+                finishedCount = event.finishedCount,
+                totalAssignedCount = event.totalAssignedCount,
             )
     }
 }


### PR DESCRIPTION
# Why
단순히 응답 대기 인원을 표시해 주는 것이어서 빨리 끝났다

# How
`isFinished` 가 false 인 유저의 수를 return 해줬다

# Result
![image](https://github.com/user-attachments/assets/18eea680-d741-4d3d-8b88-b1dfed20de5c)

# Link

BG-306