### PR TITLE
[BG-326]: 테스트 컨테이너 환경 세팅 (3h / 2h)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("com.auth0:java-jwt:3.18.3")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     // aws
     implementation("software.amazon.awssdk:s3:2.17.89")
@@ -31,6 +32,10 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
 
     testImplementation(kotlin("test"))
+    testImplementation("com.redis.testcontainers:testcontainers-redis-junit:1.6.4")
+    testImplementation("org.testcontainers:mysql:1.16.0")
+    testImplementation("org.testcontainers:testcontainers:1.19.0")
+    testImplementation("org.testcontainers:kafka:1.17.6")
 }
 
 tasks.withType<KotlinCompile> {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("com.auth0:java-jwt:3.18.3")
+    implementation("com.mysql:mysql-connector-j:8.4.0")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")

--- a/api/src/test/kotlin/com/backgu/amaker/api/auth/service/AuthFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/auth/service/AuthFacadeServiceTest.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.api.auth.service
 
 import com.backgu.amaker.api.auth.dto.JwtTokenDto
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.fixture.AuthFixture
 import com.backgu.amaker.api.security.jwt.component.JwtComponent
 import com.ninjasquad.springmockk.MockkBean
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.transaction.annotation.Transactional
 import kotlin.test.Test
@@ -19,8 +19,7 @@ import kotlin.test.Test
 @ExtendWith(SpringExtension::class)
 @AutoConfigureMockMvc
 @Transactional
-@SpringBootTest
-class AuthFacadeServiceTest {
+class AuthFacadeServiceTest : IntegrationTest() {
     @Autowired
     lateinit var authFacadeService: AuthFacadeService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/config/WebSocketConfigTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/config/WebSocketConfigTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.chat.config
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.fixture.StompFixtureFacade
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -12,7 +13,7 @@ import kotlin.test.Test
 
 @DisplayName("웹소켓 설정 테스트")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class WebSocketConfigTest {
+class WebSocketConfigTest : IntegrationTest() {
     @Autowired
     lateinit var fixtures: StompFixtureFacade
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/controller/ChatControllerTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/controller/ChatControllerTest.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.api.chat.controller
 
 import com.backgu.amaker.api.chat.dto.request.ChatCreateRequest
 import com.backgu.amaker.api.chat.dto.response.DefaultChatWithUserResponse
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.fixture.StompFixtureFacade
 import com.backgu.amaker.domain.chat.ChatRoom
 import org.assertj.core.api.Assertions.assertThat
@@ -20,7 +21,7 @@ import kotlin.test.Test
 @DisplayName("ChatController 테스트")
 @Transactional
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class ChatControllerTest {
+class ChatControllerTest : IntegrationTest() {
     @Autowired
     lateinit var fixtures: StompFixtureFacade
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatFacadeServiceTest.kt
@@ -5,6 +5,7 @@ import com.backgu.amaker.api.chat.dto.ChatListDto
 import com.backgu.amaker.api.chat.dto.ChatQuery
 import com.backgu.amaker.api.chat.dto.ChatWithUserDto
 import com.backgu.amaker.api.chat.dto.DefaultChatWithUserDto
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.fixture.ChatFixtureFacade
@@ -16,14 +17,12 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import kotlin.test.Test
 
 @DisplayName("ChatFacadeService 테스트")
 @Transactional
-@SpringBootTest
-class ChatFacadeServiceTest {
+class ChatFacadeServiceTest : IntegrationTest() {
     @Autowired
     lateinit var chatFacadeService: ChatFacadeService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomFacadeServiceTest.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.api.chat.service
 
 import com.backgu.amaker.api.chat.dto.BriefChatRoomViewDto
 import com.backgu.amaker.api.chat.dto.ChatRoomsViewDto
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.fixture.ChatRoomFacadeFixture
@@ -17,13 +18,11 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 @DisplayName("ChatRoomFacadeService 테스트")
 @Transactional
-@SpringBootTest
-class ChatRoomFacadeServiceTest {
+class ChatRoomFacadeServiceTest : IntegrationTest() {
     @Autowired
     private lateinit var chatRoomFixture: ChatRoomFixture
 
@@ -112,39 +111,32 @@ class ChatRoomFacadeServiceTest {
         val workspace = fixtures.workspaceFixture.createPersistedWorkspace(name = "test-workspace")
         fixtures.workspaceUserFixture.createPersistedWorkspaceUser(workspace.id, leader.id, member.map { it.id })
 
-        val defaultChatRoom =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
+        val defaultChatRoom = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(
             defaultChatRoom.id,
             member.map { it.id }.plus(leader.id),
         )
 
-        val leaderNotRegistered1 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leaderNotRegistered1 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(leaderNotRegistered1.id, member.map { it.id })
-        val leaderNotRegistered2 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leaderNotRegistered2 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(leaderNotRegistered2.id, member.map { it.id })
-        val leaderNotRegistered3 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leaderNotRegistered3 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(leaderNotRegistered3.id, member.map { it.id })
 
-        val leadRegistered1 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leadRegistered1 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(
             leadRegistered1.id,
             member.map { it.id }.plus(leader.id),
         )
-        val leadRegistered2 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leadRegistered2 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(
             leadRegistered2.id,
             member.map { it.id }.plus(leader.id),
         )
 
         // when
-        val result: BriefChatRoomViewDto =
-            chatRoomFacadeService.findChatRooms(leaderId, workspace.id)
+        val result: BriefChatRoomViewDto = chatRoomFacadeService.findChatRooms(leaderId, workspace.id)
 
         // then
         assertThat(result.chatRooms).isNotNull
@@ -167,39 +159,32 @@ class ChatRoomFacadeServiceTest {
         val workspace = fixtures.workspaceFixture.createPersistedWorkspace(name = "test-workspace")
         fixtures.workspaceUserFixture.createPersistedWorkspaceUser(workspace.id, leader.id, member.map { it.id })
 
-        val defaultChatRoom =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
+        val defaultChatRoom = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(
             defaultChatRoom.id,
             member.map { it.id }.plus(leader.id),
         )
 
-        val leaderNotRegistered1 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leaderNotRegistered1 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(leaderNotRegistered1.id, member.map { it.id })
-        val leaderNotRegistered2 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leaderNotRegistered2 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(leaderNotRegistered2.id, member.map { it.id })
-        val leaderNotRegistered3 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leaderNotRegistered3 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(leaderNotRegistered3.id, member.map { it.id })
 
-        val leadRegistered1 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leadRegistered1 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(
             leadRegistered1.id,
             member.map { it.id }.plus(leader.id),
         )
-        val leadRegistered2 =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val leadRegistered2 = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(
             leadRegistered2.id,
             member.map { it.id }.plus(leader.id),
         )
 
         // when
-        val result: BriefChatRoomViewDto =
-            chatRoomFacadeService.findNotRegisteredChatRooms(leaderId, workspace.id)
+        val result: BriefChatRoomViewDto = chatRoomFacadeService.findNotRegisteredChatRooms(leaderId, workspace.id)
 
         // then
         assertThat(result.chatRooms).isNotNull
@@ -230,8 +215,7 @@ class ChatRoomFacadeServiceTest {
         fixtures.workspaceUserFixture.createPersistedWorkspaceUser(workspace.id, leader.id, member.map { it.id })
 
         // when
-        val result: BriefChatRoomViewDto =
-            chatRoomFacadeService.findChatRooms(leaderId, workspace.id)
+        val result: BriefChatRoomViewDto = chatRoomFacadeService.findChatRooms(leaderId, workspace.id)
 
         // then
         assertThat(result.chatRooms).isNotNull
@@ -243,8 +227,7 @@ class ChatRoomFacadeServiceTest {
     fun joinChatRoom() {
         // given
         val (workspace, defaultChatRoom, members) = fixtures.setUp(userId = "leader")
-        val newChatRoom =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val newChatRoom = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
 
         // when
         val chatRoomUser = chatRoomFacadeService.joinChatRoom(members[0].id, workspace.id, newChatRoom.id)
@@ -270,10 +253,13 @@ class ChatRoomFacadeServiceTest {
         fixtures.chatRoomFixture.deleteChatRoom(noChatRoomId)
 
         // when & then
-        assertThatThrownBy { chatRoomFacadeService.joinChatRoom(members[0].id, workspace.id, noChatRoomId) }
-            .isInstanceOf(BusinessException::class.java)
-            .extracting("statusCode")
-            .isEqualTo(StatusCode.CHAT_ROOM_NOT_FOUND)
+        assertThatThrownBy {
+            chatRoomFacadeService.joinChatRoom(
+                members[0].id,
+                workspace.id,
+                noChatRoomId,
+            )
+        }.isInstanceOf(BusinessException::class.java).extracting("statusCode").isEqualTo(StatusCode.CHAT_ROOM_NOT_FOUND)
     }
 
     @Test
@@ -281,13 +267,17 @@ class ChatRoomFacadeServiceTest {
     fun joinAlreadyJoinedChatRoom() {
         // given
         val (workspace, defaultChatRoom, members) = fixtures.setUp(userId = "leader")
-        val newChatRoom =
-            fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
+        val newChatRoom = fixtures.chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.CUSTOM)
         fixtures.chatRoomUserFixture.createPersistedChatRoomUser(newChatRoom.id, members.map { it.id })
 
         // when & then
-        assertThatThrownBy { chatRoomFacadeService.joinChatRoom(members[0].id, workspace.id, newChatRoom.id) }
-            .isInstanceOf(BusinessException::class.java)
+        assertThatThrownBy {
+            chatRoomFacadeService.joinChatRoom(
+                members[0].id,
+                workspace.id,
+                newChatRoom.id,
+            )
+        }.isInstanceOf(BusinessException::class.java)
             .extracting("statusCode")
             .isEqualTo(StatusCode.CHAT_ROOM_USER_ALREADY_EXIST)
     }

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.chat.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.fixture.ChatRoomFacadeFixture
 import com.backgu.amaker.domain.chat.ChatRoomType
 import com.backgu.amaker.domain.workspace.WorkspaceUserStatus
@@ -7,13 +8,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional
-@SpringBootTest
 @DisplayName("ChatRoomService 테스트")
-class ChatRoomServiceTest {
+class ChatRoomServiceTest : IntegrationTest() {
     @Autowired
     lateinit var chatRoomService: ChatRoomService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomUserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.chat.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.fixture.ChatFixtureFacade
@@ -12,14 +13,12 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import kotlin.test.Test
 
 @DisplayName("ChatRoomUserService 테스트")
 @Transactional
-@SpringBootTest
-class ChatRoomUserServiceTest {
+class ChatRoomUserServiceTest : IntegrationTest() {
     @Autowired
     lateinit var chatRoomUserService: ChatRoomUserService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.chat.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.fixture.ChatFixtureFacade
 import com.backgu.amaker.domain.chat.ChatRoomType
@@ -9,13 +10,11 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 @DisplayName("ChatService 테스트")
 @Transactional
-@SpringBootTest
-class ChatServiceTest {
+class ChatServiceTest : IntegrationTest() {
     @Autowired
     lateinit var chatService: ChatService
 
@@ -28,7 +27,7 @@ class ChatServiceTest {
         fun setUp(
             @Autowired fixture: ChatFixtureFacade,
         ) {
-            fixture.setUp(userId = "basic-data-set-up")
+            fixture.setUp()
         }
     }
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/common/container/IntegrationTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/common/container/IntegrationTest.kt
@@ -1,0 +1,42 @@
+package com.backgu.amaker.api.common.container
+
+import com.redis.testcontainers.RedisContainer
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@SpringBootTest
+@Testcontainers
+class IntegrationTest {
+    companion object {
+        private val REDIS_CONTAINER: RedisContainer = RedisContainer(RedisContainer.DEFAULT_IMAGE_NAME.withTag("6"))
+        private val MYSQL_CONTAINER: MySQLContainer<*> =
+            MySQLContainer(DockerImageName.parse("mysql:8.0.26"))
+                .withDatabaseName("amaker")
+                .withUsername("user")
+                .withPassword("password")
+        private val KAFKA_CONTAINER: KafkaContainer =
+            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+
+        init {
+            REDIS_CONTAINER.start()
+            MYSQL_CONTAINER.start()
+            KAFKA_CONTAINER.start()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun overrideProps(registry: DynamicPropertyRegistry) {
+            registry.add("spring.redis.host") { REDIS_CONTAINER.host }
+            registry.add("spring.redis.port") { REDIS_CONTAINER.firstMappedPort }
+            registry.add("spring.datasource.url") { MYSQL_CONTAINER.jdbcUrl }
+            registry.add("spring.datasource.username") { MYSQL_CONTAINER.username }
+            registry.add("spring.datasource.password") { MYSQL_CONTAINER.password }
+            registry.add("spring.kafka.bootstrap-servers") { KAFKA_CONTAINER.bootstrapServers }
+        }
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/api/event/service/EventCommentFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/event/service/EventCommentFacadeServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.event.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.event.dto.ReplyCommentCreateDto
@@ -8,7 +9,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.transaction.annotation.Transactional
@@ -16,8 +16,7 @@ import kotlin.test.Test
 
 @DisplayName("EventFacadeService 테스트")
 @Transactional
-@SpringBootTest
-class EventCommentFacadeServiceTest {
+class EventCommentFacadeServiceTest : IntegrationTest() {
     @Autowired
     lateinit var eventCommentFacadeService: EventCommentFacadeService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/event/service/EventFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/event/service/EventFacadeServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.event.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.event.dto.ReplyEventCreateDto
 import com.backgu.amaker.api.fixture.EventFixtureFacade
 import com.backgu.amaker.domain.chat.ChatRoom
@@ -8,15 +9,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import kotlin.test.Test
 
 @DisplayName("EventFacadeService 테스트")
 @Transactional
-@SpringBootTest
-class EventFacadeServiceTest {
+class EventFacadeServiceTest : IntegrationTest() {
     @Autowired
     lateinit var eventFacadeService: EventFacadeService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/security/jwt/component/JwtComponentTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/security/jwt/component/JwtComponentTest.kt
@@ -1,19 +1,18 @@
 package com.backgu.amaker.api.security.jwt.component
 
 import com.auth0.jwt.exceptions.JWTDecodeException
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.domain.user.UserRole
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import kotlin.test.Test
 
 @DisplayName("JwtService 테스트")
 @ExtendWith(SpringExtension::class)
-@SpringBootTest
-class JwtComponentTest {
+class JwtComponentTest : IntegrationTest() {
     @Autowired
     lateinit var jwtComponent: JwtComponent
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/user/service/UserFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/user/service/UserFacadeServiceTest.kt
@@ -1,18 +1,17 @@
 package com.backgu.amaker.api.user.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.fixture.UserFixture
 import com.backgu.amaker.api.user.dto.EmailExistsDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import kotlin.test.Test
 
 @DisplayName("UserFacadeService 테스트")
 @Transactional
-@SpringBootTest
-class UserFacadeServiceTest {
+class UserFacadeServiceTest : IntegrationTest() {
     @Autowired
     private lateinit var userFacadeService: UserFacadeService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/user/service/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/user/service/UserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.user.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.common.service.IdPublisher
@@ -11,13 +12,11 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 @DisplayName("UserService 테스트")
 @Transactional
-@SpringBootTest
-class UserServiceTest {
+class UserServiceTest : IntegrationTest() {
     @Autowired
     private lateinit var userService: UserService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.workspace.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.fixture.WorkspaceFixture.Companion.createWorkspaceRequest
@@ -21,14 +22,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 
 @DisplayName("WorkspaceFacadeService 테스트")
 @Transactional
-@SpringBootTest
 @AutoConfigureMockMvc
-class WorkspaceFacadeServiceTest {
+class WorkspaceFacadeServiceTest : IntegrationTest() {
     @Autowired
     private lateinit var workspaceFixtureFacade: WorkspaceFixtureFacade
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.workspace.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.fixture.WorkspaceFixtureFacade
@@ -10,14 +11,12 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import kotlin.test.Test
 
 @DisplayName("WorkspaceService 테스트")
 @Transactional
-@SpringBootTest
-class WorkspaceServiceTest {
+class WorkspaceServiceTest : IntegrationTest() {
     @Autowired
     lateinit var fixtures: WorkspaceFixtureFacade
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceUserServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceUserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.workspace.service
 
+import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.common.exception.BusinessException
 import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.api.fixture.WorkspaceFixtureFacade
@@ -8,14 +9,12 @@ import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
 import kotlin.test.Test
 
 @DisplayName("WorkspaceUserService 테스트")
 @Transactional
-@SpringBootTest
-class WorkspaceUserServiceTest {
+class WorkspaceUserServiceTest : IntegrationTest() {
     @Autowired
     lateinit var workspaceUserService: WorkspaceUserService
 

--- a/api/src/test/resources/application.yaml
+++ b/api/src/test/resources/application.yaml
@@ -2,12 +2,6 @@ spring:
   application:
     name: a-maker
 
-  datasource:
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test;MODE=MySQL
-
   jpa:
     database: mysql
     hibernate:
@@ -27,11 +21,6 @@ spring:
 
   kafka:
     bootstrap-servers: [ "localhost:9092" ]
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
 
 
 oauth:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,5 @@ subprojects {
         testImplementation("io.mockk:mockk:1.13.11")
         testImplementation("com.ninja-squad:springmockk:4.0.2")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-        testRuntimeOnly("com.h2database:h2")
     }
 }

--- a/notification/build.gradle.kts
+++ b/notification/build.gradle.kts
@@ -15,8 +15,12 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":infra"))
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("org.springframework.boot:spring-boot-starter-web")
+
     testImplementation(kotlin("test"))
+    testImplementation("com.redis.testcontainers:testcontainers-redis-junit:1.6.4")
+    testImplementation("org.testcontainers:mysql:1.16.0")
+    testImplementation("org.testcontainers:testcontainers:1.19.0")
+    testImplementation("org.testcontainers:kafka:1.17.6")
 }
 
 tasks.withType<KotlinCompile> {

--- a/notification/src/test/kotlin/com/backgu/amaker/notification/common/container/IntegrationTest.kt
+++ b/notification/src/test/kotlin/com/backgu/amaker/notification/common/container/IntegrationTest.kt
@@ -1,0 +1,42 @@
+package com.backgu.amaker.notification.common.container
+
+import com.redis.testcontainers.RedisContainer
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+@SpringBootTest
+@Testcontainers
+class IntegrationTest {
+    companion object {
+        private val REDIS_CONTAINER: RedisContainer = RedisContainer(RedisContainer.DEFAULT_IMAGE_NAME.withTag("6"))
+        private val MYSQL_CONTAINER: MySQLContainer<*> =
+            MySQLContainer(DockerImageName.parse("mysql:8.0.26"))
+                .withDatabaseName("amaker")
+                .withUsername("user")
+                .withPassword("password")
+        private val KAFKA_CONTAINER: KafkaContainer =
+            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+
+        init {
+            KAFKA_CONTAINER.start()
+            REDIS_CONTAINER.start()
+            MYSQL_CONTAINER.start()
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun overrideProps(registry: DynamicPropertyRegistry) {
+            registry.add("spring.redis.host") { REDIS_CONTAINER.host }
+            registry.add("spring.redis.port") { REDIS_CONTAINER.firstMappedPort }
+            registry.add("spring.datasource.url") { MYSQL_CONTAINER.jdbcUrl }
+            registry.add("spring.datasource.username") { MYSQL_CONTAINER.username }
+            registry.add("spring.datasource.password") { MYSQL_CONTAINER.password }
+            registry.add("spring.kafka.bootstrap-servers") { KAFKA_CONTAINER.bootstrapServers }
+        }
+    }
+}

--- a/notification/src/test/kotlin/com/backgu/amaker/notification/service/NotificationWithCallBackServiceImplTest.kt
+++ b/notification/src/test/kotlin/com/backgu/amaker/notification/service/NotificationWithCallBackServiceImplTest.kt
@@ -4,6 +4,7 @@ import com.backgu.amaker.application.notification.mail.event.EmailEvent
 import com.backgu.amaker.application.notification.service.NotificationWithCallBackService
 import com.backgu.amaker.infra.mail.constants.EmailConstants
 import com.backgu.amaker.infra.mail.service.EmailHandler
+import com.backgu.amaker.notification.common.container.IntegrationTest
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.verify
@@ -15,7 +16,7 @@ import kotlin.test.Test
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class NotificationWithCallBackServiceImplTest {
+class NotificationWithCallBackServiceImplTest : IntegrationTest() {
     @Autowired
     lateinit var notificationWithCallBackServiceImpl: NotificationWithCallBackService
 

--- a/notification/src/test/resources/application.yaml
+++ b/notification/src/test/resources/application.yaml
@@ -2,12 +2,6 @@ spring:
   application:
     name: a-maker
 
-  datasource:
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test;MODE=MySQL
-
   jpa:
     database: mysql
     hibernate:
@@ -24,11 +18,3 @@ spring:
           auth: true
           starttls:
             enable: true
-
-  kafka:
-    bootstrap-servers: [ "localhost:9092" ]
-
-  data:
-    redis:
-      host: localhost
-      port: 6379


### PR DESCRIPTION
# Why

db는 h2로 인메모리로 올려서 테스트하고 있다.
하지만 레디스, 카프카 등 외부 의존성이 커지면서 인메모리 테스트용 어플리케이션만으로는 힘들다는 것을 느꼈다.
때문에 테스트 컨테이너 세팅을 했다.


# Link

BG-326