### PR TITLE
[BG-252]: 워크스페이스에 유저를 초대하는 API를 개발한다 (2h / 2h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/api/common/exception/StatusCode.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/common/exception/StatusCode.kt
@@ -32,6 +32,7 @@ enum class StatusCode(
     // workspace
     WORKSPACE_NOT_FOUND("4000", "워크스페이스를 찾을 수 없습니다."),
     INVALID_WORKSPACE_CREATE("4000", "잘못된 워크스페이스 생성 요청입니다."),
+    INVALID_WORKSPACE_INVITE("4000", "워크스페이스에 초대할 수 없습니다."),
 
     // workspaceUser
     WORKSPACE_UNREACHABLE("4000", "워크스페이스에 접근할 수 없습니다."),

--- a/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserController.kt
@@ -2,13 +2,14 @@ package com.backgu.amaker.api.user.controller
 
 import com.backgu.amaker.api.common.dto.response.ApiResult
 import com.backgu.amaker.api.common.infra.ApiHandler
+import com.backgu.amaker.api.user.dto.request.EmailExistsRequest
 import com.backgu.amaker.api.user.dto.response.EmailExistsResponse
 import com.backgu.amaker.api.user.service.UserFacadeService
-import jakarta.validation.constraints.Email
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -19,12 +20,12 @@ class UserController(
 ) : UserSwagger {
     @GetMapping("/email/exists")
     override fun checkEmail(
-        @RequestParam @Email email: String,
+        @ModelAttribute @Valid emailExistsRequest: EmailExistsRequest,
     ): ResponseEntity<ApiResult<EmailExistsResponse>> =
         ResponseEntity.ok().body(
             apiHandler.onSuccess(
                 EmailExistsResponse.of(
-                    userFacadeService.existsByEmail(email),
+                    userFacadeService.existsByEmail(emailExistsRequest.email),
                 ),
             ),
         )

--- a/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserSwagger.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.api.user.controller
 
 import com.backgu.amaker.api.common.dto.response.ApiResult
+import com.backgu.amaker.api.user.dto.request.EmailExistsRequest
 import com.backgu.amaker.api.user.dto.response.EmailExistsResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -21,6 +22,6 @@ interface UserSwagger {
         ],
     )
     fun checkEmail(
-        @Email email: String,
+        @Email email: EmailExistsRequest,
     ): ResponseEntity<ApiResult<EmailExistsResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/user/dto/request/EmailExistsRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/user/dto/request/EmailExistsRequest.kt
@@ -1,0 +1,12 @@
+package com.backgu.amaker.api.user.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotEmpty
+
+data class EmailExistsRequest(
+    @field:NotEmpty
+    @field:Email
+    @Schema(description = "확인할 이메일", example = "abc@example.com")
+    val email: String,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/api/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/user/service/UserService.kt
@@ -5,12 +5,9 @@ import com.backgu.amaker.api.common.exception.StatusCode
 import com.backgu.amaker.domain.user.User
 import com.backgu.amaker.infra.jpa.user.entity.UserEntity
 import com.backgu.amaker.infra.jpa.user.reposotory.UserRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-
-private val logger = KotlinLogging.logger {}
 
 @Service
 @Transactional(readOnly = true)
@@ -23,12 +20,7 @@ class UserService(
         return savedUser.toDomain()
     }
 
-    fun getById(id: String): User =
-        userRepository.findByIdOrNull(id)?.toDomain() ?: run {
-            // TODO 로깅 전략 세우기
-            logger.error { "User not found : $id" }
-            throw BusinessException(StatusCode.USER_NOT_FOUND)
-        }
+    fun getById(id: String): User = userRepository.findByIdOrNull(id)?.toDomain() ?: throw BusinessException(StatusCode.USER_NOT_FOUND)
 
     fun getByEmail(email: String): User =
         userRepository.findByEmail(email)?.toDomain() ?: throw BusinessException(

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceController.kt
@@ -4,15 +4,17 @@ import com.backgu.amaker.api.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.api.common.dto.response.ApiResult
 import com.backgu.amaker.api.common.infra.ApiHandler
 import com.backgu.amaker.api.security.JwtAuthentication
-import com.backgu.amaker.api.workspace.dto.WorkspaceUserDto
 import com.backgu.amaker.api.workspace.dto.request.WorkspaceCreateRequest
+import com.backgu.amaker.api.workspace.dto.request.WorkspaceInviteRequest
 import com.backgu.amaker.api.workspace.dto.response.WorkspaceResponse
+import com.backgu.amaker.api.workspace.dto.response.WorkspaceUserResponse
 import com.backgu.amaker.api.workspace.dto.response.WorkspacesResponse
 import com.backgu.amaker.api.workspace.service.WorkspaceFacadeService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -74,12 +76,41 @@ class WorkspaceController(
             ),
         )
 
+    @PostMapping("/{workspace-id}/invite")
+    override fun inviteWorkspace(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("workspace-id") workspaceId: Long,
+        @ModelAttribute @Valid workspaceInviteRequest: WorkspaceInviteRequest,
+    ): ResponseEntity<ApiResult<WorkspaceUserResponse>> =
+        ResponseEntity
+            .ok()
+            .body(
+                apiHandler.onSuccess(
+                    WorkspaceUserResponse.of(
+                        workspaceFacadeService.inviteWorkspaceUser(
+                            token.id,
+                            workspaceId,
+                            workspaceInviteRequest.email,
+                        ),
+                    ),
+                ),
+            )
+
     @PutMapping("/{workspace-id}/invite/activate")
     override fun activateWorkspaceInvite(
         @AuthenticationPrincipal token: JwtAuthentication,
         @PathVariable("workspace-id") workspaceId: Long,
-    ): ResponseEntity<ApiResult<WorkspaceUserDto>> =
+    ): ResponseEntity<ApiResult<WorkspaceUserResponse>> =
         ResponseEntity
             .ok()
-            .body(apiHandler.onSuccess(workspaceFacadeService.activateWorkspaceUser(token.id, workspaceId)))
+            .body(
+                apiHandler.onSuccess(
+                    WorkspaceUserResponse.of(
+                        workspaceFacadeService.activateWorkspaceUser(
+                            token.id,
+                            workspaceId,
+                        ),
+                    ),
+                ),
+            )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceSwagger.kt
@@ -3,9 +3,10 @@ package com.backgu.amaker.api.workspace.controller
 import com.backgu.amaker.api.chat.dto.response.ChatRoomResponse
 import com.backgu.amaker.api.common.dto.response.ApiResult
 import com.backgu.amaker.api.security.JwtAuthentication
-import com.backgu.amaker.api.workspace.dto.WorkspaceUserDto
 import com.backgu.amaker.api.workspace.dto.request.WorkspaceCreateRequest
+import com.backgu.amaker.api.workspace.dto.request.WorkspaceInviteRequest
 import com.backgu.amaker.api.workspace.dto.response.WorkspaceResponse
+import com.backgu.amaker.api.workspace.dto.response.WorkspaceUserResponse
 import com.backgu.amaker.api.workspace.dto.response.WorkspacesResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -15,6 +16,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 
@@ -89,5 +92,20 @@ interface WorkspaceSwagger {
     fun activateWorkspaceInvite(
         @Parameter(hidden = true) token: JwtAuthentication,
         workspaceId: Long,
-    ): ResponseEntity<ApiResult<WorkspaceUserDto>>
+    ): ResponseEntity<ApiResult<WorkspaceUserResponse>>
+
+    @Operation(summary = "워크스페이스 유저 초대", description = "해당 이메일로 워크스페이스에 초대합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "워크스페이스 유저 초대 성공",
+            ),
+        ],
+    )
+    fun inviteWorkspace(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("workspace-id") workspaceId: Long,
+        @ModelAttribute @Valid email: WorkspaceInviteRequest,
+    ): ResponseEntity<ApiResult<WorkspaceUserResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceSwagger.kt
@@ -106,6 +106,6 @@ interface WorkspaceSwagger {
     fun inviteWorkspace(
         @AuthenticationPrincipal token: JwtAuthentication,
         @PathVariable("workspace-id") workspaceId: Long,
-        @ModelAttribute @Valid email: WorkspaceInviteRequest,
+        @ModelAttribute @Valid workspaceInviteRequest: WorkspaceInviteRequest,
     ): ResponseEntity<ApiResult<WorkspaceUserResponse>>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/dto/WorkspaceUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/dto/WorkspaceUserDto.kt
@@ -1,22 +1,25 @@
 package com.backgu.amaker.api.workspace.dto
 
+import com.backgu.amaker.domain.workspace.WorkspaceRole
 import com.backgu.amaker.domain.workspace.WorkspaceUser
-import io.swagger.v3.oas.annotations.media.Schema
+import com.backgu.amaker.domain.workspace.WorkspaceUserStatus
 
 class WorkspaceUserDto(
-    @Schema(description = "워크스페이스 ID", example = "231")
+    val email: String,
     val workspaceId: Long,
-    @Schema(description = "워크스페이스 권한", example = "Leader")
-    val workspaceRole: String,
-    @Schema(description = "워크스페이스 상태", example = "ACTIVE")
-    val status: String,
+    val workspaceRole: WorkspaceRole,
+    val status: WorkspaceUserStatus,
 ) {
     companion object {
-        fun of(workspaceUser: WorkspaceUser): WorkspaceUserDto =
+        fun of(
+            email: String,
+            workspaceUser: WorkspaceUser,
+        ): WorkspaceUserDto =
             WorkspaceUserDto(
+                email = email,
                 workspaceId = workspaceUser.workspaceId,
-                workspaceRole = workspaceUser.workspaceRole.value,
-                status = workspaceUser.status.value,
+                workspaceRole = workspaceUser.workspaceRole,
+                status = workspaceUser.status,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/dto/request/WorkspaceInviteRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/dto/request/WorkspaceInviteRequest.kt
@@ -1,0 +1,12 @@
+package com.backgu.amaker.api.workspace.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotEmpty
+
+data class WorkspaceInviteRequest(
+    @field:NotEmpty
+    @field:Email
+    @Schema(description = "초대할 사용자 이메일", example = "abc@example.com")
+    val email: String,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/dto/response/WorkspaceUserResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/dto/response/WorkspaceUserResponse.kt
@@ -1,0 +1,27 @@
+package com.backgu.amaker.api.workspace.dto.response
+
+import com.backgu.amaker.api.workspace.dto.WorkspaceUserDto
+import com.backgu.amaker.domain.workspace.WorkspaceRole
+import com.backgu.amaker.domain.workspace.WorkspaceUserStatus
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class WorkspaceUserResponse(
+    @Schema(description = "이메일", example = "abc@example.com")
+    val email: String,
+    @Schema(description = "워크스페이스 id", example = "1")
+    val workspaceId: Long,
+    @Schema(description = "워크스페이스 권한(MEMBER, LEADER)", example = "MEMBER")
+    var workspaceRole: WorkspaceRole,
+    @Schema(description = "워크스페이스 가입 상태(PENDING, ACTIVE)", example = "PENDING")
+    var status: WorkspaceUserStatus,
+) {
+    companion object {
+        fun of(workspaceUser: WorkspaceUserDto) =
+            WorkspaceUserResponse(
+                email = workspaceUser.email,
+                workspaceId = workspaceUser.workspaceId,
+                workspaceRole = workspaceUser.workspaceRole,
+                status = workspaceUser.status,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeService.kt
@@ -96,6 +96,25 @@ class WorkspaceFacadeService(
 
         chatRoomUserService.save(chatRoomService.getDefaultChatRoomByWorkspaceId(workspaceId).addUser(user))
 
-        return WorkspaceUserDto.of(workspaceUser)
+        return WorkspaceUserDto.of(user.email, workspaceUser)
+    }
+
+    @Transactional
+    fun inviteWorkspaceUser(
+        userId: String,
+        workspaceId: Long,
+        inviteeEmail: String,
+    ): WorkspaceUserDto {
+        val user = userService.getById(userId)
+        val workspace = workspaceService.getById(workspaceId)
+        workspaceUserService.verifyUserHasAdminPrivileges(workspace, user)
+
+        val invitee = userService.getByEmail(inviteeEmail)
+        workspaceUserService.validateUserNotRelatedInWorkspace(invitee, workspace)
+
+        val workspaceUser = workspaceUserService.save(workspace.inviteWorkspace(invitee))
+        notificationEventService.publishNotificationEvent(WorkspaceInvitedEvent(invitee, workspace))
+
+        return WorkspaceUserDto.of(invitee.email, workspaceUser)
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceService.kt
@@ -25,10 +25,7 @@ class WorkspaceService(
     }
 
     fun getById(id: Long): Workspace =
-        workspaceRepository.findByIdOrNull(id)?.toDomain() ?: run {
-            logger.error { "Workspace not found : $id" }
-            throw BusinessException(StatusCode.WORKSPACE_NOT_FOUND)
-        }
+        workspaceRepository.findByIdOrNull(id)?.toDomain() ?: throw BusinessException(StatusCode.WORKSPACE_NOT_FOUND)
 
     fun getWorkspaceByIds(workspaceIds: List<Long>): List<Workspace> =
         workspaceRepository.findByWorkspaceIds(workspaceIds).map {

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceUserService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceUserService.kt
@@ -38,6 +38,15 @@ class WorkspaceUserService(
         }
     }
 
+    fun validateUserNotRelatedInWorkspace(
+        user: User,
+        workspace: Workspace,
+    ) {
+        if (workspaceUserRepository.existsByUserIdAndWorkspaceId(user.id, workspace.id)) {
+            throw BusinessException(StatusCode.INVALID_WORKSPACE_INVITE)
+        }
+    }
+
     fun getWorkspaceUser(
         workspace: Workspace,
         user: User,

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/workspace/repository/WorkspaceUserRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/workspace/repository/WorkspaceUserRepository.kt
@@ -18,6 +18,11 @@ interface WorkspaceUserRepository : JpaRepository<WorkspaceUserEntity, Long> {
         status: WorkspaceUserStatus,
     ): Boolean
 
+    fun existsByUserIdAndWorkspaceId(
+        userId: String,
+        workspaceId: Long,
+    ): Boolean
+
     @Query("select wu from WorkspaceUser wu where wu.userId = :userId and wu.workspaceId = :workspaceId")
     fun findByUserIdAndWorkspaceId(
         userId: String,


### PR DESCRIPTION
# Why

* 워크스페이스에 유저를 초대하는 API 개발
* 기존에 초대로직을 그대로 유지하여 다른 표현계층을 연결해주는 느낌이라 간단하다.

# Prize

* queryString으로 매핑되는 부분이 기존에는 `@RequestParam`으로 되어있는데 이렇게 했을 때, 기존 에러 메시지랑 다르게 나가는 문제가 있어서 `@ModelAttribute`로 바꿔주었다.


# Link

BG-252