### PR TITLE
[BG-318]: RMQ notification 브로커 만들기 (2h / 2h)

### DIFF
--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
     implementation("jakarta.persistence:jakarta.persistence-api")
     implementation("jakarta.annotation:jakarta.annotation-api")
+    //implementation("org.springframework.boot:spring-boot-starter-amqp")
+
+    //testImplementation("org.springframework.amqp:spring-rabbit-test")
     kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 group = "com.backgu.amaker"
 version = "0.0.1-SNAPSHOT"
 
+kapt {
+    correctErrorTypes = true
+}
+
 repositories {
     mavenCentral()
 }
@@ -31,9 +35,9 @@ dependencies {
     implementation("com.querydsl:querydsl-apt:5.0.0:jakarta")
     implementation("jakarta.persistence:jakarta.persistence-api")
     implementation("jakarta.annotation:jakarta.annotation-api")
-    //implementation("org.springframework.boot:spring-boot-starter-amqp")
+    implementation("org.springframework.boot:spring-boot-starter-amqp")
 
-    //testImplementation("org.springframework.amqp:spring-rabbit-test")
+    testImplementation("org.springframework.amqp:spring-rabbit-test")
     kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/config/NotificationRMQEventPublisherConfig.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/config/NotificationRMQEventPublisherConfig.kt
@@ -1,0 +1,32 @@
+package com.backgu.amaker.infra.notification.rmq.config
+
+import com.backgu.amaker.infra.notification.rmq.serivce.RMQEventPublisher
+import com.backgu.amaker.infra.rmq.config.RMQConfig
+import org.springframework.amqp.core.AcknowledgeMode
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+@Configuration
+@Import(RMQConfig::class)
+class NotificationRMQEventPublisherConfig(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val jackson2JsonMessageConverter: Jackson2JsonMessageConverter,
+) {
+    @Bean
+    fun rabbitListenerContainerFactory(connectionFactory: ConnectionFactory): RabbitListenerContainerFactory<*> {
+        val factory = SimpleRabbitListenerContainerFactory()
+        factory.setConnectionFactory(connectionFactory)
+        factory.setMessageConverter(jackson2JsonMessageConverter)
+        factory.setAcknowledgeMode(AcknowledgeMode.MANUAL)
+        return factory
+    }
+
+    @Bean
+    fun notificationRMQEventPublisher(): RMQEventPublisher = RMQEventPublisher(applicationEventPublisher)
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/config/NotificationRMQProducerConfig.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/config/NotificationRMQProducerConfig.kt
@@ -1,0 +1,27 @@
+package com.backgu.amaker.infra.notification.rmq.config
+
+import com.backgu.amaker.application.notification.service.NotificationEventService
+import com.backgu.amaker.infra.notification.rmq.serivce.NotificationRMQEventService
+import com.backgu.amaker.infra.rmq.config.RMQConfig
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+@Configuration
+@Import(RMQConfig::class)
+class NotificationRMQProducerConfig(
+    private val jackson2JsonMessageConverter: Jackson2JsonMessageConverter,
+) {
+    @Bean
+    fun rabbitTemplate(connectionFactory: ConnectionFactory): RabbitTemplate {
+        val rabbitTemplate = RabbitTemplate(connectionFactory)
+        rabbitTemplate.messageConverter = jackson2JsonMessageConverter
+        return rabbitTemplate
+    }
+
+    @Bean
+    fun notificationRMQEventService(rabbitTemplate: RabbitTemplate): NotificationEventService = NotificationRMQEventService(rabbitTemplate)
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/serivce/NotificationRMQEventService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/serivce/NotificationRMQEventService.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.infra.notification.rmq.serivce
+
+import com.backgu.amaker.application.notification.event.NotificationEvent
+import com.backgu.amaker.application.notification.service.NotificationEventService
+import com.backgu.amaker.infra.rmq.config.RMQConfig
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+
+class NotificationRMQEventService(
+    private val rabbitTemplate: RabbitTemplate,
+) : NotificationEventService {
+    override fun publishNotificationEvent(notificationEvent: NotificationEvent) {
+        rabbitTemplate.convertAndSend(RMQConfig.NOTIFICATION_QUEUE, notificationEvent)
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/serivce/RMQEventPublisher.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/notification/rmq/serivce/RMQEventPublisher.kt
@@ -1,0 +1,37 @@
+package com.backgu.amaker.infra.notification.rmq.serivce
+
+import com.backgu.amaker.application.notification.event.NotificationEventWithCallback
+import com.backgu.amaker.application.notification.mail.event.EmailEvent
+import com.backgu.amaker.infra.rmq.config.RMQConfig
+import com.rabbitmq.client.Channel
+import org.springframework.amqp.rabbit.annotation.RabbitListener
+import org.springframework.amqp.support.AmqpHeaders
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.messaging.handler.annotation.Headers
+
+class RMQEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    @RabbitListener(queues = [RMQConfig.NOTIFICATION_QUEUE])
+    fun publish(
+        notificationEvent: EmailEvent,
+        channel: Channel,
+        @Headers headers: Map<String, Any>,
+    ) {
+        val deliveryTag = headers[AmqpHeaders.DELIVERY_TAG] as Long
+
+        applicationEventPublisher.publishEvent(
+            object : NotificationEventWithCallback {
+                override val notificationEvent = notificationEvent
+
+                override fun postHandle() {
+                    channel.basicAck(deliveryTag, false)
+                }
+
+                override fun onFail(exception: Exception) {
+                    channel.basicNack(deliveryTag, false, true)
+                }
+            },
+        )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/rmq/config/RMQConfig.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/rmq/config/RMQConfig.kt
@@ -1,0 +1,47 @@
+package com.backgu.amaker.infra.rmq.config
+
+import org.springframework.amqp.core.Binding
+import org.springframework.amqp.core.BindingBuilder
+import org.springframework.amqp.core.Queue
+import org.springframework.amqp.core.TopicExchange
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "spring.rabbitmq")
+class RMQConfig {
+    companion object {
+        const val NOTIFICATION_QUEUE = "notification"
+        const val NOTIFICATION_EXCHANGE = "notification"
+        const val NOTIFICATION_ROUTING_KEY = "notification"
+    }
+
+    lateinit var host: String
+    var port: Int = 0
+    lateinit var username: String
+    lateinit var password: String
+
+    @Bean
+    fun jackson2JsonMessageConverter(): Jackson2JsonMessageConverter = Jackson2JsonMessageConverter()
+
+    @Bean
+    fun queue(): Queue = Queue(RMQConfig.NOTIFICATION_QUEUE, false)
+
+    @Bean
+    fun topicExchange(): TopicExchange = TopicExchange(RMQConfig.NOTIFICATION_EXCHANGE)
+
+    @Bean
+    fun binding(): Binding = BindingBuilder.bind(queue()).to(topicExchange()).with(RMQConfig.NOTIFICATION_ROUTING_KEY)
+
+    @Bean
+    fun connectionFactory(): ConnectionFactory {
+        val connectionFactory = CachingConnectionFactory(host, port)
+        connectionFactory.username = username
+        connectionFactory.setPassword(password)
+        return connectionFactory
+    }
+}

--- a/notification/build.gradle.kts
+++ b/notification/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":infra"))
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation(kotlin("test"))
 }
 


### PR DESCRIPTION
# Why

* auto configuration 설정을 하려다 하지 않았다.
* 일단 그 부분보다도 의존성이 받아지는 순간 rmq 클라이언트가 생성되었기 때문에 그 부분을 먼저 고민하는게 좋을 것 같았다.

# How

config는 기본적으로 kafka로 유지


# Result

* 이메일 전송 성공
![스크린샷 2024-08-02 오후 1 19 08](https://github.com/user-attachments/assets/3404d009-3797-4aa0-b5c6-407da9735b5d)

# Link

BG-318