### PR TITLE
[BG-343]: 채팅 커서 조회 redis cache 구현 (12h / 6h)

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -37,9 +37,9 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("com.redis.testcontainers:testcontainers-redis-junit:1.6.4")
-    testImplementation("org.testcontainers:mysql:1.16.0")
-    testImplementation("org.testcontainers:testcontainers:1.19.0")
-    testImplementation("org.testcontainers:kafka:1.17.6")
+    testImplementation("org.testcontainers:mysql:1.20.0")
+    testImplementation("org.testcontainers:testcontainers:1.20.0")
+    testImplementation("org.testcontainers:kafka:1.20.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/api/src/main/kotlin/com/backgu/amaker/api/AMakerApiApplication.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/AMakerApiApplication.kt
@@ -13,7 +13,14 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EntityScan(basePackages = ["com.backgu.amaker.infra"])
 @EnableRedisRepositories(basePackages = ["com.backgu.amaker.infra.redis"])
 @EnableJpaRepositories(basePackages = ["com.backgu.amaker.infra"])
-@SpringBootApplication(scanBasePackages = ["com.backgu.amaker.api", "com.backgu.amaker.infra.jpa"])
+@SpringBootApplication(
+    scanBasePackages = [
+        "com.backgu.amaker.api",
+        "com.backgu.amaker.infra.jpa",
+        "com.backgu.amaker.infra.redis.chat",
+        "com.backgu.amaker.infra.redis.user",
+    ],
+)
 class AMakerApiApplication
 
 fun main(args: Array<String>) {

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/config/ChatServiceConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/config/ChatServiceConfig.kt
@@ -1,26 +1,58 @@
 package com.backgu.amaker.api.chat.config
 
+import com.backgu.amaker.application.chat.service.ChatCacheService
+import com.backgu.amaker.application.chat.service.ChatQueryService
 import com.backgu.amaker.application.chat.service.ChatRoomService
+import com.backgu.amaker.application.chat.service.ChatRoomUserCacheService
 import com.backgu.amaker.application.chat.service.ChatRoomUserService
 import com.backgu.amaker.application.chat.service.ChatService
+import com.backgu.amaker.application.chat.service.ChatUserCacheFacadeService
+import com.backgu.amaker.application.event.service.EventAssignedUserService
+import com.backgu.amaker.application.user.service.UserCacheService
+import com.backgu.amaker.application.user.service.UserService
 import com.backgu.amaker.infra.jpa.chat.repository.ChatRepository
 import com.backgu.amaker.infra.jpa.chat.repository.ChatRoomRepository
 import com.backgu.amaker.infra.jpa.chat.repository.ChatRoomUserRepository
+import com.backgu.amaker.infra.redis.chat.repository.ChatCacheRepository
+import com.backgu.amaker.infra.redis.chat.repository.ChatRoomUserCacheRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class ChatServiceConfig(
-    val chatRepository: ChatRepository,
-    val chatRoomUserRepository: ChatRoomUserRepository,
-    val chatRoomRepository: ChatRoomRepository,
-) {
+class ChatServiceConfig {
     @Bean
-    fun chatService() = ChatService(chatRepository)
+    fun chatService(chatRepository: ChatRepository) = ChatService(chatRepository)
 
     @Bean
-    fun chatRoomUserService() = ChatRoomUserService(chatRoomUserRepository)
+    fun chatRoomUserService(chatRoomUserRepository: ChatRoomUserRepository) = ChatRoomUserService(chatRoomUserRepository)
 
     @Bean
-    fun chatRoomService() = ChatRoomService(chatRoomRepository)
+    fun chatRoomService(chatRoomRepository: ChatRoomRepository) = ChatRoomService(chatRoomRepository)
+
+    @Bean
+    fun chatQueryService(chatRepository: ChatRepository) = ChatQueryService(chatRepository)
+
+    @Bean
+    fun chatCacheService(chatCacheRepository: ChatCacheRepository) = ChatCacheService(chatCacheRepository)
+
+    @Bean
+    fun chatRoomUserCacheService(chatRoomUserCacheRepository: ChatRoomUserCacheRepository) =
+        ChatRoomUserCacheService(chatRoomUserCacheRepository)
+
+    @Bean
+    fun chatUserCacheService(
+        chatCacheService: ChatCacheService,
+        userCacheService: UserCacheService,
+        chatRoomUserCacheService: ChatRoomUserCacheService,
+        userService: UserService,
+        chatService: ChatService,
+        eventAssignedUserService: EventAssignedUserService,
+    ) = ChatUserCacheFacadeService(
+        chatCacheService,
+        userCacheService,
+        chatRoomUserCacheService,
+        userService,
+        chatService,
+        eventAssignedUserService,
+    )
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/ChatWithUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/ChatWithUserDto.kt
@@ -1,10 +1,14 @@
 package com.backgu.amaker.api.chat.dto
 
+import com.backgu.amaker.api.event.dto.EventWithUserDto
 import com.backgu.amaker.api.user.dto.UserDto
 import com.backgu.amaker.domain.chat.ChatType
+import com.backgu.amaker.domain.chat.ChatWithUser
+import com.backgu.amaker.domain.chat.DefaultChatWithUser
+import com.backgu.amaker.domain.event.EventWithUser
 import java.time.LocalDateTime
 
-interface ChatWithUserDto<T> {
+sealed interface ChatWithUserDto<T> {
     val id: Long
     val chatRoomId: Long
     val content: T
@@ -12,4 +16,31 @@ interface ChatWithUserDto<T> {
     val createdAt: LocalDateTime
     val updatedAt: LocalDateTime
     val user: UserDto
+
+    companion object {
+        fun <T> of(chatWithUser: ChatWithUser<T>): ChatWithUserDto<out Any> =
+            when (chatWithUser) {
+                is DefaultChatWithUser ->
+                    DefaultChatWithUserDto(
+                        id = chatWithUser.id,
+                        chatRoomId = chatWithUser.chatRoomId,
+                        content = chatWithUser.content,
+                        chatType = chatWithUser.chatType,
+                        createdAt = chatWithUser.createdAt,
+                        updatedAt = chatWithUser.updatedAt,
+                        user = UserDto.of(chatWithUser.user),
+                    )
+
+                else ->
+                    EventChatWithUserDto(
+                        id = chatWithUser.id,
+                        chatRoomId = chatWithUser.chatRoomId,
+                        content = EventWithUserDto.of(chatWithUser.content as EventWithUser),
+                        chatType = chatWithUser.chatType,
+                        createdAt = chatWithUser.createdAt,
+                        updatedAt = chatWithUser.updatedAt,
+                        user = UserDto.of(chatWithUser.user),
+                    )
+            }
+    }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/DefaultChatWithUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/DefaultChatWithUserDto.kt
@@ -3,8 +3,8 @@ package com.backgu.amaker.api.chat.dto
 import com.backgu.amaker.api.user.dto.UserDto
 import com.backgu.amaker.domain.chat.Chat
 import com.backgu.amaker.domain.chat.ChatType
+import com.backgu.amaker.domain.chat.DefaultChatWithUser
 import com.backgu.amaker.domain.user.User
-import com.backgu.amaker.infra.jpa.chat.query.ChatWithUserQuery
 import java.time.LocalDateTime
 
 class DefaultChatWithUserDto(
@@ -31,21 +31,35 @@ class DefaultChatWithUserDto(
                 user = UserDto(id = user.id, name = user.name, email = user.email, picture = user.picture),
             )
 
-        fun of(chatWithUserQuery: ChatWithUserQuery) =
+        fun of(chatWithUser: DefaultChatWithUser) =
             DefaultChatWithUserDto(
-                id = chatWithUserQuery.id,
-                chatRoomId = chatWithUserQuery.chatRoomId,
-                content = chatWithUserQuery.content,
-                chatType = chatWithUserQuery.chatType,
-                createdAt = chatWithUserQuery.createdAt,
-                updatedAt = chatWithUserQuery.updatedAt,
+                id = chatWithUser.id,
+                chatRoomId = chatWithUser.chatRoomId,
+                content = chatWithUser.content,
+                chatType = chatWithUser.chatType,
+                createdAt = chatWithUser.createdAt,
+                updatedAt = chatWithUser.updatedAt,
                 user =
                     UserDto(
-                        id = chatWithUserQuery.user.id,
-                        name = chatWithUserQuery.user.name,
-                        email = chatWithUserQuery.user.email,
-                        picture = chatWithUserQuery.user.picture,
+                        id = chatWithUser.user.id,
+                        name = chatWithUser.user.name,
+                        email = chatWithUser.user.email,
+                        picture = chatWithUser.user.picture,
                     ),
+            )
+
+        fun of(
+            defaultChatWithUser: DefaultChatWithUser,
+            user: User,
+        ): DefaultChatWithUserDto =
+            DefaultChatWithUserDto(
+                id = defaultChatWithUser.id,
+                chatRoomId = defaultChatWithUser.chatRoomId,
+                content = defaultChatWithUser.content,
+                chatType = defaultChatWithUser.chatType,
+                createdAt = defaultChatWithUser.createdAt,
+                updatedAt = defaultChatWithUser.updatedAt,
+                user = UserDto(id = user.id, name = user.name, email = user.email, picture = user.picture),
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/EventChatWithUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/EventChatWithUserDto.kt
@@ -3,6 +3,7 @@ package com.backgu.amaker.api.chat.dto
 import com.backgu.amaker.api.event.dto.EventWithUserDto
 import com.backgu.amaker.api.user.dto.UserDto
 import com.backgu.amaker.domain.chat.ChatType
+import com.backgu.amaker.domain.chat.ChatWithUser
 import java.time.LocalDateTime
 
 class EventChatWithUserDto(
@@ -16,7 +17,7 @@ class EventChatWithUserDto(
 ) : ChatWithUserDto<EventWithUserDto> {
     companion object {
         fun of(
-            chat: ChatWithUserDto<*>,
+            chat: ChatWithUser<*>,
             eventDto: EventWithUserDto,
         ): EventChatWithUserDto =
             EventChatWithUserDto(
@@ -26,7 +27,7 @@ class EventChatWithUserDto(
                 chatType = chat.chatType,
                 createdAt = chat.createdAt,
                 updatedAt = chat.updatedAt,
-                user = chat.user,
+                user = UserDto.of(chat.user),
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/ChatListResponse.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/dto/response/ChatListResponse.kt
@@ -21,7 +21,7 @@ class ChatListResponse(
                 cursor = chatListDto.cursor,
                 size = chatListDto.size,
                 chatList = chatListDto.chatList.map { ChatWithUserResponse.of(it) },
-                nextCursor = chatListDto.chatList.first().id,
+                chatListDto.chatList.firstOrNull()?.id ?: chatListDto.cursor,
             )
 
         fun afterOf(chatListDto: ChatListDto) =
@@ -30,7 +30,7 @@ class ChatListResponse(
                 cursor = chatListDto.cursor,
                 size = chatListDto.size,
                 chatList = chatListDto.chatList.map { ChatWithUserResponse.of(it) },
-                nextCursor = chatListDto.chatList.last().id,
+                nextCursor = chatListDto.chatList.lastOrNull()?.id ?: chatListDto.cursor,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/chat/service/ChatRoomFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/chat/service/ChatRoomFacadeService.kt
@@ -57,7 +57,7 @@ class ChatRoomFacadeService(
 
         // 채팅방에 참여한 유저들의 도메인 조회
         val userMap: Map<String, User> =
-            userService.findAllByUserIds(chatRoomUsers.map { it.userId }).associateBy { it.id }
+            userService.getAllByUserIds(chatRoomUsers.map { it.userId }).associateBy { it.id }
 
         // 채팅방의 읽지 않은 채팅 수 조회
         val unreadChatCountMap =

--- a/api/src/main/kotlin/com/backgu/amaker/api/config/RedisConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/config/RedisConfig.kt
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
@@ -25,11 +24,11 @@ class RedisConfig {
     }
 
     @Bean
-    fun redisTemplate(): RedisTemplate<String, Long> {
-        val template = RedisTemplate<String, Long>()
+    fun redisTemplate(): RedisTemplate<String, Any> {
+        val template = RedisTemplate<String, Any>()
         template.connectionFactory = redisConnectionFactory()
         template.keySerializer = StringRedisSerializer()
-        template.valueSerializer = GenericJackson2JsonRedisSerializer()
+        template.valueSerializer = StringRedisSerializer()
         return template
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/EventWithUserDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/EventWithUserDto.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.api.event.dto
 
 import com.backgu.amaker.api.user.dto.UserDto
 import com.backgu.amaker.domain.event.Event
+import com.backgu.amaker.domain.event.EventWithUser
 import com.backgu.amaker.domain.user.User
 import java.time.LocalDateTime
 
@@ -19,7 +20,7 @@ data class EventWithUserDto(
         fun of(
             event: Event,
             users: List<User>,
-            finishedCount: Int,
+            finishedCount: Int = 0,
         ): EventWithUserDto =
             EventWithUserDto(
                 id = event.id,
@@ -30,6 +31,18 @@ data class EventWithUserDto(
                 users = users.map { UserDto.of(it) },
                 finishedCount = finishedCount,
                 totalAssignedCount = users.size,
+            )
+
+        fun of(eventWithUser: EventWithUser): EventWithUserDto =
+            EventWithUserDto(
+                id = eventWithUser.id,
+                eventTitle = eventWithUser.eventTitle,
+                deadLine = eventWithUser.deadLine,
+                notificationStartTime = eventWithUser.notificationStartTime,
+                notificationInterval = eventWithUser.notificationInterval,
+                users = eventWithUser.users.map { UserDto.of(it) },
+                finishedCount = eventWithUser.finishedCount,
+                totalAssignedCount = eventWithUser.totalAssignedCount,
             )
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/user/config/UserServiceConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/user/config/UserServiceConfig.kt
@@ -1,9 +1,11 @@
 package com.backgu.amaker.api.user.config
 
+import com.backgu.amaker.application.user.service.UserCacheService
 import com.backgu.amaker.application.user.service.UserDeviceService
 import com.backgu.amaker.application.user.service.UserService
 import com.backgu.amaker.infra.jpa.user.reposotory.UserDeviceRepository
 import com.backgu.amaker.infra.jpa.user.reposotory.UserRepository
+import com.backgu.amaker.infra.redis.user.repository.UserCacheRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -14,4 +16,7 @@ class UserServiceConfig {
 
     @Bean
     fun userDeviceService(userDeviceRepository: UserDeviceRepository): UserDeviceService = UserDeviceService(userDeviceRepository)
+
+    @Bean
+    fun userCacheService(userCacheRepository: UserCacheRepository): UserCacheService = UserCacheService(userCacheRepository)
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserController.kt
@@ -40,7 +40,7 @@ class UserController(
     override fun registerUserDevice(
         @AuthenticationPrincipal token: JwtAuthentication,
         @RequestBody @Valid userDeviceDto: UserDeviceCreateRequest,
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<Unit> {
         userFacadeService.registerUserDevice(userDeviceDto.toDto(userId = token.id))
         return ResponseEntity.status(HttpStatus.CREATED).build()
     }

--- a/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/user/controller/UserSwagger.kt
@@ -22,7 +22,7 @@ interface UserSwagger {
             ),
         ],
     )
-    fun checkEmail(email: EmailExistsRequest): ResponseEntity<ApiResult<EmailExistsResponse>>
+    fun checkEmail(emailExistsRequest: EmailExistsRequest): ResponseEntity<ApiResult<EmailExistsResponse>>
 
     @Operation(summary = "fcm 디바이스 토큰 등록", description = "fcm 푸시 알림 전송용 토큰을 등록합니다.")
     @ApiResponses(
@@ -36,5 +36,5 @@ interface UserSwagger {
     fun registerUserDevice(
         token: JwtAuthentication,
         userDeviceDto: UserDeviceCreateRequest,
-    ): ResponseEntity<Void>
+    ): ResponseEntity<Unit>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeService.kt
@@ -97,7 +97,7 @@ class WorkspaceFacadeService(
 
         val workspaceUsers = workspaceUserService.findWorkSpaceUserByWorkspaceId(workspaceId)
 
-        val users = userService.findAllByUserIds(workspaceUsers.map { it.userId })
+        val users = userService.getAllByUserIds(workspaceUsers.map { it.userId })
 
         val workspaceUserMap = workspaceUsers.associateBy { it.userId }
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatFacadeServiceTest.kt
@@ -87,6 +87,7 @@ class ChatFacadeServiceTest : IntegrationTest() {
         // then
         assertThat(previousChat.chatList).hasSize(10)
         assertThat(previousChat.size).isEqualTo(previousChat.chatList.size)
+        assertThat(previousChat.cursor).isEqualTo(currentChat.id)
         assertThat(previousChat.cursor).isNotEqualTo(prevChats.last().id)
     }
 
@@ -111,6 +112,7 @@ class ChatFacadeServiceTest : IntegrationTest() {
         // then
         assertThat(previousChat.chatList).hasSize(5)
         assertThat(previousChat.size).isEqualTo(previousChat.chatList.size)
+        assertThat(previousChat.cursor).isEqualTo(currentChat.id)
         assertThat(previousChat.cursor).isNotEqualTo(prevChats.last().id)
     }
 
@@ -143,7 +145,7 @@ class ChatFacadeServiceTest : IntegrationTest() {
         // given
         val userId = "test-user-id"
         val chatRoom: ChatRoom = fixture.setUp(userId = userId)
-        val prevChats = fixture.chatFixture.createPersistedChats(chatRoom.id, userId, 10)
+        fixture.chatFixture.createPersistedChats(chatRoom.id, userId, 10)
         val currentChat: Chat = fixture.chatFixture.createPersistedChat(chatRoom.id, userId, "현재 테스트 메시지")
         fixture.chatFixture.createPersistedChats(chatRoom.id, userId, 30)
 
@@ -154,32 +156,36 @@ class ChatFacadeServiceTest : IntegrationTest() {
                 ChatQuery(currentChat.id, chatRoom.id, 10),
             )
 
+        for (chatWithUserDto in findAfterChats.chatList) {
+            println(chatWithUserDto.id)
+        }
+        println(findAfterChats.chatList.last().id)
         // then
         assertThat(findAfterChats.chatList).hasSize(10)
         assertThat(findAfterChats.size).isEqualTo(findAfterChats.chatList.size)
-        assertThat(findAfterChats.cursor).isNotEqualTo(prevChats.last().id)
+        assertThat(findAfterChats.cursor).isEqualTo(currentChat.id)
+        assertThat(currentChat.id).isNotEqualTo(findAfterChats.chatList.last().id)
     }
 
     @Test
-    @DisplayName("이전 채팅 조회 테스트")
+    @DisplayName("이후 채팅 조회 테스트 - 이후 채팅이 없는 경우")
     fun getAfterChatTestWhenNoAfterChat() {
         // given
         val userId = "test-user-id"
         val chatRoom: ChatRoom = fixture.setUp(userId = userId)
         val prevChats: List<Chat> = fixture.chatFixture.createPersistedChats(chatRoom.id, userId, 30)
         val currentChat: Chat = fixture.chatFixture.createPersistedChat(chatRoom.id, userId, "현재 테스트 메시지")
-        fixture.chatFixture.createPersistedChats(chatRoom.id, userId, 10)
 
         // when
-        val findPrevChats: ChatListDto =
+        val findAfterChats: ChatListDto =
             chatFacadeService.getAfterChat(
                 userId,
                 ChatQuery(currentChat.id, chatRoom.id, 10),
             )
 
         // then
-        assertThat(findPrevChats.chatList).hasSize(10)
-        assertThat(findPrevChats.cursor).isNotEqualTo(prevChats.last().id)
+        assertThat(findAfterChats.chatList).hasSize(0)
+        assertThat(findAfterChats.cursor).isEqualTo(currentChat.id)
     }
 
     @Test

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatRoomFacadeServiceTest.kt
@@ -4,7 +4,6 @@ import com.backgu.amaker.api.chat.dto.BriefChatRoomViewDto
 import com.backgu.amaker.api.chat.dto.ChatRoomsViewDto
 import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.fixture.ChatRoomFacadeFixture
-import com.backgu.amaker.api.fixture.ChatRoomFixture
 import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.common.status.StatusCode
 import com.backgu.amaker.domain.chat.Chat
@@ -23,9 +22,6 @@ import org.springframework.transaction.annotation.Transactional
 @DisplayName("ChatRoomFacadeService 테스트")
 @Transactional
 class ChatRoomFacadeServiceTest : IntegrationTest() {
-    @Autowired
-    private lateinit var chatRoomFixture: ChatRoomFixture
-
     @Autowired
     lateinit var chatRoomFacadeService: ChatRoomFacadeService
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/chat/service/ChatServiceTest.kt
@@ -1,8 +1,8 @@
 package com.backgu.amaker.api.chat.service
 
-import com.backgu.amaker.api.chat.service.query.ChatQueryService
 import com.backgu.amaker.api.common.container.IntegrationTest
 import com.backgu.amaker.api.fixture.ChatFixtureFacade
+import com.backgu.amaker.application.chat.service.ChatQueryService
 import com.backgu.amaker.application.chat.service.ChatService
 import com.backgu.amaker.common.status.StatusCode
 import com.backgu.amaker.domain.chat.ChatRoomType

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/chat/Chat.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/chat/Chat.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.domain.chat
 
 import com.backgu.amaker.domain.event.ReplyEvent
+import com.backgu.amaker.domain.user.User
 import java.time.LocalDateTime
 
 class Chat(
@@ -28,5 +29,35 @@ class Chat(
                 .minusMinutes(notificationStartMinute.toLong()),
         notificationInterval = notificationInterval,
         eventDetails = eventDetails,
+    )
+
+    fun createDefaultChatWithUser(user: User) =
+        DefaultChatWithUser(
+            id = id,
+            chatRoomId = chatRoomId,
+            content = content,
+            chatType = chatType,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            user = user,
+        )
+
+    fun createEventChatWithUser(
+        event: ReplyEvent,
+        user: User,
+        assignedUsers: List<User>,
+    ) = EventChatWithUser(
+        id = id,
+        chatRoomId = chatRoomId,
+        content =
+            event.createEventWithUser(
+                users = assignedUsers,
+                finishedCount = 0,
+                totalAssignedCount = assignedUsers.size,
+            ),
+        chatType = chatType,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        user = user,
     )
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/chat/ChatWithUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/chat/ChatWithUser.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.domain.chat
+
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+interface ChatWithUser<T> {
+    val id: Long
+    val chatRoomId: Long
+    val content: T
+    val chatType: ChatType
+    val createdAt: LocalDateTime
+    val updatedAt: LocalDateTime
+    val user: User
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/chat/DefaultChatWithUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/chat/DefaultChatWithUser.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.domain.chat
+
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+class DefaultChatWithUser(
+    override val id: Long = 0L,
+    override val chatRoomId: Long,
+    override val content: String,
+    override val chatType: ChatType,
+    override val createdAt: LocalDateTime,
+    override val updatedAt: LocalDateTime,
+    override val user: User,
+) : ChatWithUser<String>

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/chat/EventChatWithUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/chat/EventChatWithUser.kt
@@ -1,0 +1,15 @@
+package com.backgu.amaker.domain.chat
+
+import com.backgu.amaker.domain.event.EventWithUser
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+class EventChatWithUser(
+    override val id: Long,
+    override val chatRoomId: Long,
+    override val content: EventWithUser,
+    override val chatType: ChatType,
+    override val createdAt: LocalDateTime,
+    override val updatedAt: LocalDateTime,
+    override val user: User,
+) : ChatWithUser<EventWithUser>

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/event/Event.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/event/Event.kt
@@ -13,4 +13,20 @@ abstract class Event(
     val updatedAt: LocalDateTime,
 ) {
     fun createAssignedUsers(userIds: List<User>): List<EventAssignedUser> = userIds.map { EventAssignedUser(eventId = id, userId = it.id) }
+
+    fun createEventWithUser(
+        users: List<User>,
+        finishedCount: Int,
+        totalAssignedCount: Int,
+    ): EventWithUser =
+        EventWithUser(
+            id,
+            eventTitle,
+            deadLine,
+            notificationStartTime,
+            notificationInterval,
+            users,
+            finishedCount,
+            totalAssignedCount,
+        )
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/event/EventWithUser.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/event/EventWithUser.kt
@@ -1,0 +1,15 @@
+package com.backgu.amaker.domain.event
+
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+data class EventWithUser(
+    val id: Long,
+    val eventTitle: String,
+    val deadLine: LocalDateTime,
+    val notificationStartTime: LocalDateTime,
+    val notificationInterval: Int,
+    val users: List<User>,
+    val finishedCount: Int,
+    val totalAssignedCount: Int,
+)

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/user/User.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/user/User.kt
@@ -16,4 +16,21 @@ class User(
     }
 
     fun isNonInvitee(invitee: User) = email != invitee.email
+
+    companion object {
+        fun of(
+            id: String,
+            name: String,
+            email: String,
+            picture: String,
+            userRole: UserRole = UserRole.USER,
+        ): User =
+            User(
+                id = id,
+                name = name,
+                email = email,
+                picture = picture,
+                userRole = userRole,
+            )
+    }
 }

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -21,6 +21,7 @@ allOpen {
 dependencies {
     implementation(project(":domain"))
     implementation(project(":common"))
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2")
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/event/DefaultChatSaveEvent.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/event/DefaultChatSaveEvent.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.application.chat.event
+
+import com.backgu.amaker.domain.chat.DefaultChatWithUser
+
+data class DefaultChatSaveEvent(
+    val chatRoomId: Long,
+    val defaultChatWithUser: DefaultChatWithUser,
+) {
+    companion object {
+        fun of(
+            chatRoomId: Long,
+            defaultChatWithUser: DefaultChatWithUser,
+        ) = DefaultChatSaveEvent(
+            chatRoomId = chatRoomId,
+            defaultChatWithUser = defaultChatWithUser,
+        )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/event/EventChatSaveEvent.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/event/EventChatSaveEvent.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.application.chat.event
+
+import com.backgu.amaker.domain.chat.EventChatWithUser
+
+data class EventChatSaveEvent(
+    val chatRoomId: Long,
+    val eventChatWithUser: EventChatWithUser,
+) {
+    companion object {
+        fun of(
+            chatRoomId: Long,
+            eventChatWithUser: EventChatWithUser,
+        ) = EventChatSaveEvent(
+            chatRoomId = chatRoomId,
+            eventChatWithUser = eventChatWithUser,
+        )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/event/FinishedCountUpdateEvent.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/event/FinishedCountUpdateEvent.kt
@@ -1,0 +1,12 @@
+package com.backgu.amaker.application.chat.event
+
+data class FinishedCountUpdateEvent(
+    val chatId: Long,
+) {
+    companion object {
+        fun of(chatId: Long) =
+            FinishedCountUpdateEvent(
+                chatId = chatId,
+            )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatCacheService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatCacheService.kt
@@ -1,0 +1,48 @@
+package com.backgu.amaker.application.chat.service
+
+import com.backgu.amaker.infra.redis.chat.data.ChatWithUserCache
+import com.backgu.amaker.infra.redis.chat.repository.ChatCacheRepository
+import org.springframework.stereotype.Service
+
+@Service
+class ChatCacheService(
+    private val chatCacheRepository: ChatCacheRepository,
+) {
+    fun saveChat(
+        chatRoomId: Long,
+        chat: ChatWithUserCache<*>,
+    ) {
+        chatCacheRepository.saveChat(chatRoomId, chat)
+    }
+
+    fun updateFinishedCount(
+        chatRoomId: Long,
+        chatId: Long,
+        finishedCount: Int,
+    ) {
+        chatCacheRepository.updateFinishedCount(
+            chatRoomId,
+            chatId,
+            finishedCount,
+        )
+    }
+
+    fun findChat(
+        chatRoomId: Long,
+        chatId: Long,
+    ): ChatWithUserCache<*>? = chatCacheRepository.findChat(chatRoomId, chatId)
+
+    fun findPreviousChats(
+        chatRoomId: Long,
+        cursor: Long,
+        count: Int,
+    ): List<ChatWithUserCache<*>> = chatCacheRepository.findPreviousChats(chatRoomId, cursor, count)
+
+    fun findAfterChats(
+        chatRoomId: Long,
+        cursor: Long,
+        count: Int,
+    ): List<ChatWithUserCache<*>> = chatCacheRepository.findAfterChats(chatRoomId, cursor, count)
+
+    fun findFirstChat(chatRoomId: Long): ChatWithUserCache<*>? = chatCacheRepository.findFirstChat(chatRoomId)
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatQueryService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatQueryService.kt
@@ -1,8 +1,8 @@
-package com.backgu.amaker.api.chat.service.query
+package com.backgu.amaker.application.chat.service
 
-import com.backgu.amaker.api.chat.dto.DefaultChatWithUserDto
 import com.backgu.amaker.common.exception.BusinessException
 import com.backgu.amaker.common.status.StatusCode
+import com.backgu.amaker.domain.chat.DefaultChatWithUser
 import com.backgu.amaker.infra.jpa.chat.repository.ChatRepository
 import org.springframework.stereotype.Service
 
@@ -14,24 +14,24 @@ class ChatQueryService(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<DefaultChatWithUserDto> =
+    ): List<DefaultChatWithUser> =
         chatRepository
             .findTopByChatRoomIdLittleThanCursorLimitCountWithUser(chatRoomId, cursor, size)
             .asReversed()
-            .map { DefaultChatWithUserDto.of(it) }
+            .map { it.toDomain() }
 
     fun findAfterChatList(
         chatRoomId: Long,
         cursor: Long,
         size: Int,
-    ): List<DefaultChatWithUserDto> =
+    ): List<DefaultChatWithUser> =
         chatRepository
             .findTopByChatRoomIdGreaterThanCursorLimitCountWithUser(chatRoomId, cursor, size)
-            .map { DefaultChatWithUserDto.of(it) }
+            .map { it.toDomain() }
 
-    fun getOneWithUser(chatId: Long?): DefaultChatWithUserDto =
-        DefaultChatWithUserDto.of(
-            chatId?.let { chatRepository.findByIdWithUser(it) }
-                ?: throw BusinessException(StatusCode.CHAT_NOT_FOUND),
-        )
+    fun getOneWithUser(chatId: Long?): DefaultChatWithUser =
+        chatId
+            ?.let { chatRepository.findByIdWithUser(it) }
+            ?.toDomain()
+            ?: throw BusinessException(StatusCode.CHAT_NOT_FOUND)
 }

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatRoomUserCacheService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatRoomUserCacheService.kt
@@ -1,0 +1,37 @@
+package com.backgu.amaker.application.chat.service
+
+import com.backgu.amaker.infra.redis.chat.data.ChatRoomUserCache
+import com.backgu.amaker.infra.redis.chat.repository.ChatRoomUserCacheRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ChatRoomUserCacheService(
+    private val chatRoomUserCacheRepository: ChatRoomUserCacheRepository,
+) {
+    fun findUserIds(chatRoomId: Long): Set<String> = chatRoomUserCacheRepository.findByIdOrNull(chatRoomId)?.userIds ?: emptySet()
+
+    fun addUser(
+        chatRoomId: Long,
+        userId: String,
+    ) {
+        val chatRoomUserCache =
+            chatRoomUserCacheRepository.findByIdOrNull(chatRoomId)
+                ?: ChatRoomUserCache(chatRoomId)
+
+        chatRoomUserCache.addUser(userId)
+        chatRoomUserCacheRepository.save(chatRoomUserCache)
+    }
+
+    fun removeUser(
+        chatRoomId: Long,
+        userId: String,
+    ) {
+        val chatRoomUserCache =
+            chatRoomUserCacheRepository.findByIdOrNull(chatRoomId)
+                ?: ChatRoomUserCache(chatRoomId)
+
+        chatRoomUserCache.removeUser(userId)
+        chatRoomUserCacheRepository.save(chatRoomUserCache)
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatUserCacheFacadeService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatUserCacheFacadeService.kt
@@ -1,0 +1,147 @@
+package com.backgu.amaker.application.chat.service
+
+import com.backgu.amaker.application.chat.event.DefaultChatSaveEvent
+import com.backgu.amaker.application.chat.event.EventChatSaveEvent
+import com.backgu.amaker.application.chat.event.FinishedCountUpdateEvent
+import com.backgu.amaker.application.event.service.EventAssignedUserService
+import com.backgu.amaker.application.user.service.UserCacheService
+import com.backgu.amaker.application.user.service.UserService
+import com.backgu.amaker.domain.chat.ChatWithUser
+import com.backgu.amaker.domain.user.User
+import com.backgu.amaker.infra.redis.chat.data.ChatWithUserCache
+import com.backgu.amaker.infra.redis.chat.data.DefaultChatWithUserCache
+import com.backgu.amaker.infra.redis.chat.data.EventChatWithUserCache
+import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Service
+class ChatUserCacheFacadeService(
+    private val chatCacheService: ChatCacheService,
+    private val userCacheService: UserCacheService,
+    private val chatRoomUserCacheService: ChatRoomUserCacheService,
+    private val userService: UserService,
+    private val chatService: ChatService,
+    private val eventAssignedUserService: EventAssignedUserService,
+) {
+    @TransactionalEventListener
+    fun saveDefaultChat(event: DefaultChatSaveEvent) {
+        chatCacheService.saveChat(event.chatRoomId, DefaultChatWithUserCache.of(event.defaultChatWithUser))
+    }
+
+    @TransactionalEventListener
+    fun saveEventChat(event: EventChatSaveEvent) {
+        chatCacheService.saveChat(event.chatRoomId, EventChatWithUserCache.of(event.eventChatWithUser))
+    }
+
+    @TransactionalEventListener
+    fun updateFinishedCount(event: FinishedCountUpdateEvent) {
+        val chat = chatService.getById(event.chatId)
+        val size = eventAssignedUserService.findAllByEventId(chat.id).filter { it.isFinished }.size
+
+        chatCacheService.updateFinishedCount(
+            chat.chatRoomId,
+            event.chatId,
+            size,
+        )
+    }
+
+    fun findChat(
+        chatRoomId: Long,
+        chatId: Long,
+    ): ChatWithUser<*>? {
+        val chat = chatCacheService.findChat(chatRoomId, chatId) ?: return null
+
+        val user =
+            userCacheService.getUserById(chat.userId) ?: userService.getById(chat.userId).also { fetchedUser ->
+                userCacheService.save(fetchedUser)
+            }
+
+        when (chat) {
+            is DefaultChatWithUserCache -> return chat.toDomain(user)
+            is EventChatWithUserCache -> {
+                val userIds = chat.content.users
+                val cachedUsers = userCacheService.findAllByUserIds(userIds)
+                val missingUserIds = userIds.filterNot { cachedUsers.any { user -> user.id == it } }
+                val fetchedUsers =
+                    userService.getAllByUserIds(missingUserIds).onEach { userCacheService.save(it) }
+                val allUsers = cachedUsers + fetchedUsers
+
+                return chat.toDomain(user, chat.content.toDomain(allUsers))
+            }
+
+            else -> {
+                throw IllegalArgumentException("Invalid chat type")
+            }
+        }
+    }
+
+    fun findPreviousChats(
+        chatRoomId: Long,
+        cursor: Long,
+        count: Int,
+    ): List<ChatWithUser<*>> {
+        val cachedUsersMap =
+            userCacheService
+                .findAllByUserIds(chatRoomUserCacheService.findUserIds(chatRoomId).toList())
+                .associateBy { it.id }
+
+        return chatCacheService
+            .findPreviousChats(chatRoomId, cursor, count)
+            .map { chat -> mapChatToDto(chatRoomId, chat, cachedUsersMap) }
+    }
+
+    fun findAfterChats(
+        chatRoomId: Long,
+        cursor: Long,
+        count: Int,
+    ): List<ChatWithUser<*>>? {
+        chatCacheService.findFirstChat(chatRoomId)?.takeIf { it.id <= cursor } ?: return null
+
+        val cachedUsersMap =
+            userCacheService
+                .findAllByUserIds(chatRoomUserCacheService.findUserIds(chatRoomId).toList())
+                .associateBy { it.id }
+
+        return chatCacheService
+            .findAfterChats(chatRoomId, cursor, count)
+            .map { chat -> mapChatToDto(chatRoomId, chat, cachedUsersMap) }
+    }
+
+    fun mapChatToDto(
+        chatRoomId: Long,
+        chat: ChatWithUserCache<*>,
+        cachedUsersMap: Map<String, User>,
+    ): ChatWithUser<*> {
+        val user =
+            userCacheService.getUserById(chat.userId)
+                ?: userService.getById(chat.userId).also { fetchedUser ->
+                    userCacheService.save(fetchedUser)
+                }
+
+        return when (chat) {
+            is DefaultChatWithUserCache -> chat.toDomain(user)
+            is EventChatWithUserCache -> {
+                val userIds = chat.content.users
+
+                val missingUserIds = userIds.filterNot { cachedUsersMap.containsKey(it) }
+
+                val fetchedUsersMap =
+                    userService
+                        .getAllByUserIds(missingUserIds)
+                        .associateBy { it.id }
+                        .onEach {
+                            chatRoomUserCacheService.addUser(chatRoomId, it.value.id)
+                            userCacheService.save(it.value)
+                        }
+
+                val allUsers = userIds.mapNotNull { cachedUsersMap[it] ?: fetchedUsersMap[it] }
+
+                return chat.toDomain(user, chat.content.toDomain(allUsers))
+            }
+
+            else -> {
+                throw IllegalArgumentException("Invalid chat type")
+            }
+        }
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatUserCacheFacadeService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/chat/service/ChatUserCacheFacadeService.kt
@@ -68,10 +68,6 @@ class ChatUserCacheFacadeService(
 
                 return chat.toDomain(user, chat.content.toDomain(allUsers))
             }
-
-            else -> {
-                throw IllegalArgumentException("Invalid chat type")
-            }
         }
     }
 

--- a/infra/src/main/kotlin/com/backgu/amaker/application/user/service/UserCacheService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/user/service/UserCacheService.kt
@@ -1,0 +1,18 @@
+package com.backgu.amaker.application.user.service
+
+import com.backgu.amaker.domain.user.User
+import com.backgu.amaker.infra.redis.user.data.UserCache
+import com.backgu.amaker.infra.redis.user.repository.UserCacheRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class UserCacheService(
+    private val userCacheRepository: UserCacheRepository,
+) {
+    fun getUserById(id: String): User? = userCacheRepository.findByIdOrNull(id)?.toDomain()
+
+    fun save(user: User) = userCacheRepository.save(UserCache.of(user)).toDomain()
+
+    fun findAllByUserIds(userIds: List<String>): List<User> = userCacheRepository.findAllById(userIds).map { it.toDomain() }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/user/service/UserService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/user/service/UserService.kt
@@ -32,18 +32,22 @@ class UserService(
 
     fun findByEmail(email: String): User? = userRepository.findByEmail(email)?.toDomain()
 
-    fun findAllByUserIds(userIds: List<String>): List<User> = userRepository.findAllByIdIn(userIds).map { it.toDomain() }
+    fun getAllByUserIds(userIds: List<String>): List<User> {
+        val users = userRepository.findAllByIdIn(userIds).map { it.toDomain() }
+        if (userIds.size != users.size) {
+            throw BusinessException(StatusCode.USER_NOT_FOUND)
+        }
+        return users
+    }
 
     fun findAllByUserIdsToMap(userIds: List<String>): Map<String, User> =
         userRepository.findAllByIdIn(userIds).map { it.toDomain() }.associateBy { it.id }
 
     fun getAllByUserEmails(userIds: List<String>): List<User> {
         val users = userRepository.findAllByEmailIn(userIds).map { it.toDomain() }
-
         if (userIds.size != users.size) {
             throw BusinessException(StatusCode.USER_NOT_FOUND)
         }
-
         return users
     }
 

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/chat/query/ChatWithUserQuery.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/chat/query/ChatWithUserQuery.kt
@@ -2,6 +2,7 @@ package com.backgu.amaker.infra.jpa.chat.query
 
 import com.backgu.amaker.domain.chat.Chat
 import com.backgu.amaker.domain.chat.ChatType
+import com.backgu.amaker.domain.chat.DefaultChatWithUser
 import com.backgu.amaker.domain.user.User
 import com.backgu.amaker.infra.jpa.user.query.UserQuery
 import com.querydsl.core.annotations.QueryProjection
@@ -21,6 +22,23 @@ class ChatWithUserQuery
         userEmail: String,
         userPicture: String,
     ) {
+        fun toDomain(): DefaultChatWithUser =
+            DefaultChatWithUser(
+                id = id,
+                chatRoomId = chatRoomId,
+                content = content,
+                chatType = chatType,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+                user =
+                    User.of(
+                        id = user.id,
+                        name = user.name,
+                        email = user.email,
+                        picture = user.picture,
+                    ),
+            )
+
         companion object {
             fun of(
                 chat: Chat,

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/ChatRoomUserCache.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/ChatRoomUserCache.kt
@@ -1,0 +1,19 @@
+package com.backgu.amaker.infra.redis.chat.data
+
+import jakarta.persistence.Id
+import org.springframework.data.redis.core.RedisHash
+
+@RedisHash("ChatRoom:User")
+class ChatRoomUserCache(
+    @Id
+    val id: Long,
+    val userIds: MutableSet<String> = mutableSetOf(),
+) {
+    fun addUser(userId: String) {
+        userIds.add(userId)
+    }
+
+    fun removeUser(userId: String) {
+        userIds.remove(userId)
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/ChatWithUserCache.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/ChatWithUserCache.kt
@@ -1,0 +1,29 @@
+package com.backgu.amaker.infra.redis.chat.data
+
+import com.backgu.amaker.domain.chat.ChatType
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import java.time.LocalDateTime
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "chatType",
+)
+@JsonSubTypes(
+    JsonSubTypes.Type(value = DefaultChatWithUserCache::class, name = "GENERAL"),
+    JsonSubTypes.Type(value = DefaultChatWithUserCache::class, name = "FILE"),
+    JsonSubTypes.Type(value = DefaultChatWithUserCache::class, name = "IMAGE"),
+    JsonSubTypes.Type(value = EventChatWithUserCache::class, name = "REPLY"),
+    JsonSubTypes.Type(value = EventChatWithUserCache::class, name = "REACTION"),
+    JsonSubTypes.Type(value = EventChatWithUserCache::class, name = "TASK"),
+)
+interface ChatWithUserCache<T> {
+    val id: Long
+    val chatRoomId: Long
+    val content: T
+    val chatType: ChatType
+    val createdAt: LocalDateTime
+    val updatedAt: LocalDateTime
+    val userId: String
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/ChatWithUserCache.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/ChatWithUserCache.kt
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
     JsonSubTypes.Type(value = EventChatWithUserCache::class, name = "REACTION"),
     JsonSubTypes.Type(value = EventChatWithUserCache::class, name = "TASK"),
 )
-interface ChatWithUserCache<T> {
+sealed interface ChatWithUserCache<T> {
     val id: Long
     val chatRoomId: Long
     val content: T

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/DefaultChatWithUserCache.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/DefaultChatWithUserCache.kt
@@ -1,0 +1,55 @@
+package com.backgu.amaker.infra.redis.chat.data
+
+import com.backgu.amaker.domain.chat.Chat
+import com.backgu.amaker.domain.chat.ChatType
+import com.backgu.amaker.domain.chat.DefaultChatWithUser
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+class DefaultChatWithUserCache(
+    override val id: Long = 0L,
+    override val chatRoomId: Long,
+    override val content: String,
+    override val chatType: ChatType,
+    override val createdAt: LocalDateTime,
+    override val updatedAt: LocalDateTime,
+    override val userId: String,
+) : ChatWithUserCache<String> {
+    fun toDomain(user: User) =
+        DefaultChatWithUser(
+            id = id,
+            chatRoomId = chatRoomId,
+            content = content,
+            chatType = chatType,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            user = user,
+        )
+
+    companion object {
+        fun of(
+            chat: Chat,
+            user: User,
+        ): DefaultChatWithUserCache =
+            DefaultChatWithUserCache(
+                id = chat.id,
+                chatRoomId = chat.chatRoomId,
+                content = chat.content,
+                chatType = chat.chatType,
+                createdAt = chat.createdAt,
+                updatedAt = chat.updatedAt,
+                userId = user.id,
+            )
+
+        fun of(chatWithUser: DefaultChatWithUser) =
+            DefaultChatWithUserCache(
+                id = chatWithUser.id,
+                chatRoomId = chatWithUser.chatRoomId,
+                content = chatWithUser.content,
+                chatType = chatWithUser.chatType,
+                createdAt = chatWithUser.createdAt,
+                updatedAt = chatWithUser.updatedAt,
+                userId = chatWithUser.user.id,
+            )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/EventChatWithUserCache.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/EventChatWithUserCache.kt
@@ -1,0 +1,48 @@
+package com.backgu.amaker.infra.redis.chat.data
+
+import com.backgu.amaker.domain.chat.ChatType
+import com.backgu.amaker.domain.chat.EventChatWithUser
+import com.backgu.amaker.domain.event.EventWithUser
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+class EventChatWithUserCache(
+    override val id: Long,
+    override val chatRoomId: Long,
+    override val content: EventWithUserCache,
+    override val chatType: ChatType,
+    override val createdAt: LocalDateTime,
+    override val updatedAt: LocalDateTime,
+    override val userId: String,
+) : ChatWithUserCache<EventWithUserCache> {
+    fun toDomain(
+        user: User,
+        eventWithUser: EventWithUser,
+    ) = EventChatWithUser(
+        id = id,
+        chatRoomId = chatRoomId,
+        content = eventWithUser,
+        chatType = chatType,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        user = user,
+    )
+
+    fun updateFinishedCount(finishedCount: Int): EventChatWithUserCache {
+        content.updateFinishedCount(finishedCount)
+        return this
+    }
+
+    companion object {
+        fun of(chat: EventChatWithUser): EventChatWithUserCache =
+            EventChatWithUserCache(
+                id = chat.id,
+                chatRoomId = chat.chatRoomId,
+                content = EventWithUserCache.of(chat.content),
+                chatType = chat.chatType,
+                createdAt = chat.createdAt,
+                updatedAt = chat.updatedAt,
+                userId = chat.user.id,
+            )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/EventWithUserCache.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/data/EventWithUserCache.kt
@@ -1,0 +1,47 @@
+package com.backgu.amaker.infra.redis.chat.data
+
+import com.backgu.amaker.domain.event.EventWithUser
+import com.backgu.amaker.domain.user.User
+import java.time.LocalDateTime
+
+class EventWithUserCache(
+    val id: Long,
+    val eventTitle: String,
+    val deadLine: LocalDateTime,
+    val notificationStartTime: LocalDateTime,
+    val notificationInterval: Int,
+    val users: List<String>,
+    var finishedCount: Int,
+    val totalAssignedCount: Int,
+) {
+    fun toDomain(users: List<User>) =
+        EventWithUser(
+            id = id,
+            eventTitle = eventTitle,
+            deadLine = deadLine,
+            notificationStartTime = notificationStartTime,
+            notificationInterval = notificationInterval,
+            users = users,
+            finishedCount = finishedCount,
+            totalAssignedCount = totalAssignedCount,
+        )
+
+    companion object {
+        fun of(eventWithUser: EventWithUser): EventWithUserCache =
+            EventWithUserCache(
+                id = eventWithUser.id,
+                eventTitle = eventWithUser.eventTitle,
+                deadLine = eventWithUser.deadLine,
+                notificationStartTime = eventWithUser.notificationStartTime,
+                notificationInterval = eventWithUser.notificationInterval,
+                users = eventWithUser.users.map { it.id },
+                finishedCount = eventWithUser.finishedCount,
+                totalAssignedCount = eventWithUser.totalAssignedCount,
+            )
+    }
+
+    fun updateFinishedCount(finishedCount: Int): EventWithUserCache {
+        this.finishedCount = finishedCount
+        return this
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/repository/ChatCacheRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/repository/ChatCacheRepository.kt
@@ -1,0 +1,113 @@
+package com.backgu.amaker.infra.redis.chat.repository
+
+import com.backgu.amaker.infra.redis.chat.data.ChatWithUserCache
+import com.backgu.amaker.infra.redis.chat.data.EventChatWithUserCache
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class ChatCacheRepository(
+    private val redisChatTemplate: RedisTemplate<String, String>,
+    private val timeObjectMapper: ObjectMapper,
+) {
+    companion object {
+        const val PREFIX = "chatRoom:"
+
+        fun key(chatRoomId: Long) = "$PREFIX$chatRoomId"
+    }
+
+    fun saveChat(
+        chatRoomId: Long,
+        chat: ChatWithUserCache<*>,
+    ) {
+        redisChatTemplate
+            .opsForZSet()
+            .add(key(chatRoomId), timeObjectMapper.writeValueAsString(chat), chat.id.toDouble())
+
+        redisChatTemplate
+            .opsForZSet()
+            .removeRange(key(chatRoomId), 0, -201)
+    }
+
+    fun updateFinishedCount(
+        chatRoomId: Long,
+        chatId: Long,
+        finishedCount: Int,
+    ) {
+        val chat =
+            redisChatTemplate
+                .opsForZSet()
+                .rangeByScore(key(chatRoomId), chatId.toDouble(), chatId.toDouble(), 0, 1)
+                ?.firstOrNull() ?: return
+
+        val chatWithUserCache = timeObjectMapper.readValue(chat, ChatWithUserCache::class.java)
+
+        if (chatWithUserCache is EventChatWithUserCache) {
+            val updatedChat = chatWithUserCache.updateFinishedCount(finishedCount)
+
+            deleteChat(chatRoomId, chatId)
+
+            redisChatTemplate
+                .opsForZSet()
+                .add(key(chatRoomId), timeObjectMapper.writeValueAsString(updatedChat), chatId.toDouble())
+        }
+    }
+
+    fun deleteChat(
+        chatRoomId: Long,
+        chatId: Long,
+    ) {
+        redisChatTemplate
+            .opsForZSet()
+            .removeRangeByScore(key(chatRoomId), chatId.toDouble(), chatId.toDouble())
+    }
+
+    fun findChat(
+        chatRoomId: Long,
+        chatId: Long,
+    ): ChatWithUserCache<*>? {
+        val chatScoreRange =
+            redisChatTemplate
+                .opsForZSet()
+                .rangeByScore(key(chatRoomId), chatId.toDouble(), chatId.toDouble(), 0, 1)
+                ?.firstOrNull()
+
+        return chatScoreRange?.let {
+            timeObjectMapper.readValue(it, ChatWithUserCache::class.java)
+        }
+    }
+
+    fun findPreviousChats(
+        chatRoomId: Long,
+        cursor: Long,
+        count: Int,
+    ): List<ChatWithUserCache<*>> =
+        redisChatTemplate
+            .opsForZSet()
+            .rangeByScore(key(chatRoomId), Double.NEGATIVE_INFINITY, (cursor - 1).toDouble(), 0, count.toLong())
+            ?.map { chat ->
+                timeObjectMapper.readValue(chat, ChatWithUserCache::class.java)
+            } ?: emptyList()
+
+    fun findAfterChats(
+        chatRoomId: Long,
+        cursor: Long,
+        count: Int,
+    ): List<ChatWithUserCache<*>> =
+        redisChatTemplate
+            .opsForZSet()
+            .rangeByScore(key(chatRoomId), (cursor + 1).toDouble(), Double.MAX_VALUE, 0, count.toLong())
+            ?.map { chat ->
+                timeObjectMapper.readValue(chat, ChatWithUserCache::class.java)
+            } ?: emptyList()
+
+    fun findFirstChat(chatRoomId: Long): ChatWithUserCache<*>? =
+        redisChatTemplate
+            .opsForZSet()
+            .range(key(chatRoomId), 0, 0)
+            ?.firstOrNull()
+            ?.let { chat ->
+                timeObjectMapper.readValue(chat, ChatWithUserCache::class.java)
+            }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/repository/ChatRoomUserCacheRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/chat/repository/ChatRoomUserCacheRepository.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.infra.redis.chat.repository
+
+import com.backgu.amaker.infra.redis.chat.data.ChatRoomUserCache
+import org.springframework.data.repository.CrudRepository
+
+interface ChatRoomUserCacheRepository : CrudRepository<ChatRoomUserCache, Long>

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/config/ModuleConfig.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/config/ModuleConfig.kt
@@ -1,0 +1,15 @@
+package com.backgu.amaker.infra.redis.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ModuleConfig {
+    @Bean
+    fun timeObjectMapper(): ObjectMapper =
+        jacksonObjectMapper()
+            .registerModules(JavaTimeModule())
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/user/data/UserCache.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/user/data/UserCache.kt
@@ -1,0 +1,36 @@
+package com.backgu.amaker.infra.redis.user.data
+
+import com.backgu.amaker.domain.user.User
+import com.backgu.amaker.domain.user.UserRole
+import jakarta.persistence.Id
+import org.springframework.data.redis.core.RedisHash
+
+@RedisHash("user")
+class UserCache(
+    @Id
+    val id: String,
+    val name: String,
+    val email: String,
+    val picture: String,
+    val userRole: UserRole = UserRole.USER,
+) {
+    fun toDomain(): User =
+        User(
+            id = id,
+            name = name,
+            email = email,
+            picture = picture,
+            userRole = userRole,
+        )
+
+    companion object {
+        fun of(user: User): UserCache =
+            UserCache(
+                id = user.id,
+                name = user.name,
+                email = user.email,
+                picture = user.picture,
+                userRole = user.userRole,
+            )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/redis/user/repository/UserCacheRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/redis/user/repository/UserCacheRepository.kt
@@ -1,0 +1,8 @@
+package com.backgu.amaker.infra.redis.user.repository
+
+import com.backgu.amaker.infra.redis.user.data.UserCache
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserCacheRepository : CrudRepository<UserCache, String>


### PR DESCRIPTION
# Why
채팅 기능 캐시를 구현하였다
처음 구현해서 생각보다 오래 걸렸다

# How

## 레디스 구조
채팅을 sorted set 에 저장하는 형태로 만들고
score 를 채팅 id 로 설정하였다

이때 유저의 정보는 쉽게 바뀔수 있기 때문에
채팅에는 유저 id 만 저장하고 
유저 상세 정보는 hash table 에 저장하였다

또한 특정 채팅방에 속한 유저를 한번에 조회하기 위해
chatroomId를 키로 하는 hash table에
유저 id를 리스트로 저장하였다

## 저장 형태
채팅과 이벤트를 생성할 때 레디스 캐시에 저장되게 만들었다
현재는 채팅방마다 200개가 저장될 수 있게 하였다

## 조회 형태
- 이전 채팅 조회
먼저 레디스를 조회하고 부족한 채팅수 만큼 db를 조회하게 함

- 이후 채팅 조회
조회 하려는 커서가 현재 레디스의 score 에 포함이 되는지 확인한다
만약 포함이 되면 레디스를 통해서 조회를 하고
포함되지 않으면 db를 호출하여 조회를 한다

# Result
![image](https://github.com/user-attachments/assets/0e8d1f73-fecc-417c-a74e-54f7a8131601)

# Link

BG-343