### PR TITLE
[BG-338]: 워크스페이스 단건 조회 API를 개발한다 (0.5h / 2h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceController.kt
@@ -76,6 +76,17 @@ class WorkspaceController(
             ),
         )
 
+    @GetMapping("/{workspace-id}")
+    override fun getWorkspace(
+        @PathVariable("workspace-id") workspaceId: Long,
+        @AuthenticationPrincipal token: JwtAuthentication,
+    ): ResponseEntity<ApiResult<WorkspaceResponse>> =
+        ResponseEntity.ok().body(
+            apiHandler.onSuccess(
+                WorkspaceResponse.of(workspaceFacadeService.getWorkspace(token.id, workspaceId)),
+            ),
+        )
+
     @PostMapping("/{workspace-id}/invite")
     override fun inviteWorkspace(
         @AuthenticationPrincipal token: JwtAuthentication,

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/controller/WorkspaceSwagger.kt
@@ -63,6 +63,22 @@ interface WorkspaceSwagger {
         @Parameter(hidden = true) token: JwtAuthentication,
     ): ResponseEntity<ApiResult<WorkspaceResponse>>
 
+    @Operation(summary = "workspace 단건 조회", description = "워크스페이스를 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "단일 워크스페이스 조회 성공",
+            ),
+        ],
+    )
+    fun getWorkspace(
+        @PathVariable
+        @Parameter(description = "워크스페이스 ID", required = true, `in` = ParameterIn.PATH)
+        workspaceId: Long,
+        token: JwtAuthentication,
+    ): ResponseEntity<ApiResult<WorkspaceResponse>>
+
     @Deprecated("사용하지 않음")
     @Operation(summary = "기본 채팅방 조회", description = "워크스페이스의 기본 채팅방을 조회합니다.")
     @ApiResponses(
@@ -90,7 +106,9 @@ interface WorkspaceSwagger {
         ],
     )
     fun activateWorkspaceInvite(
-        @Parameter(hidden = true) token: JwtAuthentication,
+        @Parameter(hidden = true)
+        token: JwtAuthentication,
+        @Parameter(description = "워크스페이스 ID", required = true, `in` = ParameterIn.PATH)
         workspaceId: Long,
     ): ResponseEntity<ApiResult<WorkspaceUserResponse>>
 

--- a/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeService.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeService.kt
@@ -56,6 +56,18 @@ class WorkspaceFacadeService(
         return WorkspaceDto.of(workspace)
     }
 
+    fun getWorkspace(
+        userId: String,
+        workspaceId: Long,
+    ): WorkspaceDto {
+        val user: User = userService.getById(userId)
+        val workspace: Workspace = workspaceService.getWorkspaceById(workspaceId)
+
+        workspaceUserService.validUserInWorkspace(user, workspace)
+
+        return WorkspaceDto.of(workspace)
+    }
+
     fun findWorkspaces(userId: String): WorkspacesDto {
         val user: User = userService.getById(userId)
 

--- a/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/workspace/service/WorkspaceFacadeServiceTest.kt
@@ -299,4 +299,39 @@ class WorkspaceFacadeServiceTest : IntegrationTest() {
         assertThat(workspaceUser.workspaceId).isEqualTo(workspace.id)
         assertThat(workspaceUser.workspaceRole).isEqualTo(WorkspaceRole.MEMBER)
     }
+
+    @Test
+    @DisplayName("워크스페이스 단건 조회")
+    fun getWorkspace() {
+        // given
+        val userId = "tester"
+        fixtures.user.createPersistedUser(userId)
+        val workspace = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = userId)
+
+        // when
+        val result = workspaceFacadeService.getWorkspace(userId, workspace.id)
+
+        // then
+        assertThat(result.workspaceId).isEqualTo(workspace.id)
+        assertThat(result.name).isEqualTo("워크스페이스1")
+    }
+
+    @Test
+    @DisplayName("워크스페이스 단건 조회 실패 - 권한 없는 워크스페이스")
+    fun getWorkspaceNotIn() {
+        val diffUser = "diffUser"
+        fixtures.user.createPersistedUser(diffUser)
+        val workspace = fixtures.workspace.createPersistedWorkspace(name = "워크스페이스1")
+        fixtures.workspaceUser.createPersistedWorkspaceUser(workspaceId = workspace.id, leaderId = diffUser)
+
+        val userId = "tester"
+        fixtures.user.createPersistedUser(userId)
+
+        // when & then
+        assertThatThrownBy { workspaceFacadeService.getWorkspace(userId, workspace.id) }
+            .isInstanceOf(BusinessException::class.java)
+            .extracting("statusCode")
+            .isEqualTo(StatusCode.WORKSPACE_UNREACHABLE)
+    }
 }


### PR DESCRIPTION
# Why
기존에 있던 메소드를 활용하면 되서 시간이 적게 걸렸다

# How
workspaceId를 이용하여 워크스페이스 정보를 가져온다

# Result
```kotlin
    fun getWorkspace(
        userId: String,
        workspaceId: Long,
    ): WorkspaceDto {
        val user: User = userService.getById(userId)
        val workspace: Workspace = workspaceService.getWorkspaceById(workspaceId)

        workspaceUserService.validUserInWorkspace(user, workspace)

        return WorkspaceDto.of(workspace)
    }
```
# Link
BG-338