### PR TITLE
[BG-22]: 배포 환경에 fcm 반영 (1h / 2h)

### DIFF
--- a/.github/workflows/ci-cd-main.yaml
+++ b/.github/workflows/ci-cd-main.yaml
@@ -126,7 +126,7 @@ jobs:
           cd ./notification/src/main/resources/
           touch ./application.yaml
           echo "${{ secrets.YAML_PROD_NOTIFICATION }}" > ./application.yaml
-          mkdir firebase
+          mkdir -p firebase
           echo "${{ secrets.FCM_ACCOUNT }}" > ./firebase/fcm.json
         shell: bash
 

--- a/.github/workflows/ci-cd-main.yaml
+++ b/.github/workflows/ci-cd-main.yaml
@@ -126,6 +126,8 @@ jobs:
           cd ./notification/src/main/resources/
           touch ./application.yaml
           echo "${{ secrets.YAML_PROD_NOTIFICATION }}" > ./application.yaml
+          mkdir firebase
+          echo "${{ secrets.FCM_ACCOUNT }}" > ./firebase/fcm.json
         shell: bash
 
       - name: Grant execute permission for gradlew


### PR DESCRIPTION
# Why

배포 환경에 FCM 알림을 쏘기위한 인증 파일이 빠져있어서 반영함
