### PR TITLE
[BG-349]: Kafka 파티셔너에서 알림 순서를 유지하는 형태로 파티셔닝 되도록 수정 (1h / 1h)

### DIFF
--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/Notification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/Notification.kt
@@ -5,4 +5,10 @@ import java.io.Serializable
 
 interface Notification : Serializable {
     val method: NotificationMethod
+    val keyPrefix: String
+    val keyValue: String
+
+    fun getNotificationKey(): String {
+        return "$keyPrefix:$keyValue"
+    }
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/PushNotification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/PushNotification.kt
@@ -6,7 +6,7 @@ import com.backgu.amaker.domain.user.UserDevice
 class PushNotification(
     override val method: NotificationMethod,
     val userDevices: List<UserDevice>,
-) : Notification{
+) : Notification {
     override val keyPrefix: String
         get() = "PUSH"
 

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/PushNotification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/PushNotification.kt
@@ -6,4 +6,10 @@ import com.backgu.amaker.domain.user.UserDevice
 class PushNotification(
     override val method: NotificationMethod,
     val userDevices: List<UserDevice>,
-) : Notification
+) : Notification{
+    override val keyPrefix: String
+        get() = "PUSH"
+
+    override val keyValue: String
+        get() = userDevices.first().userId
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/UserFulfilledNotification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/UserFulfilledNotification.kt
@@ -6,4 +6,10 @@ import com.backgu.amaker.domain.user.User
 class UserFulfilledNotification(
     val user: User,
     override val method: RealTimeNotificationMethod,
-) : RealTimeBasedNotification(method)
+) : RealTimeBasedNotification(method){
+    override val keyPrefix: String
+        get() = "USER"
+
+    override val keyValue: String
+        get() = user.id
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/UserFulfilledNotification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/UserFulfilledNotification.kt
@@ -6,7 +6,7 @@ import com.backgu.amaker.domain.user.User
 class UserFulfilledNotification(
     val user: User,
     override val method: RealTimeNotificationMethod,
-) : RealTimeBasedNotification(method){
+) : RealTimeBasedNotification(method) {
     override val keyPrefix: String
         get() = "USER"
 

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/UserNotification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/UserNotification.kt
@@ -5,4 +5,10 @@ import com.backgu.amaker.domain.notifiacation.method.RealTimeNotificationMethod
 open class UserNotification(
     val userId: String,
     override val method: RealTimeNotificationMethod,
-) : RealTimeBasedNotification(method)
+) : RealTimeBasedNotification(method) {
+    override val keyPrefix: String
+        get() = "USER"
+
+    override val keyValue: String
+        get() = userId
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/WorkspaceNotification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/WorkspaceNotification.kt
@@ -5,7 +5,7 @@ import com.backgu.amaker.domain.notifiacation.method.RealTimeNotificationMethod
 open class WorkspaceNotification(
     open val workspaceId: Long,
     override val method: RealTimeNotificationMethod,
-) : RealTimeBasedNotification(method){
+) : RealTimeBasedNotification(method) {
     override val keyPrefix: String
         get() = "WORKSPACE"
 

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/WorkspaceNotification.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/notifiacation/WorkspaceNotification.kt
@@ -5,4 +5,10 @@ import com.backgu.amaker.domain.notifiacation.method.RealTimeNotificationMethod
 open class WorkspaceNotification(
     open val workspaceId: Long,
     override val method: RealTimeNotificationMethod,
-) : RealTimeBasedNotification(method)
+) : RealTimeBasedNotification(method){
+    override val keyPrefix: String
+        get() = "WORKSPACE"
+
+    override val keyValue: String
+        get() = workspaceId.toString()
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/notification/kafka/service/KafkaNotificationEventService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/notification/kafka/service/KafkaNotificationEventService.kt
@@ -9,6 +9,6 @@ class KafkaNotificationEventService(
     private val kafkaTemplate: KafkaTemplate<String, Notification>,
 ) : NotificationEventService {
     override fun publishNotificationEvent(notification: Notification) {
-        kafkaTemplate.send(KafkaConfig.NOTIFICATION_TOPIC, notification)
+        kafkaTemplate.send(KafkaConfig.NOTIFICATION_TOPIC, notification.getNotificationKey(), notification)
     }
 }


### PR DESCRIPTION
# Why

유저 기반, 워크스페이스 기반 등등의 알람이 각각의 키를 가지도록 하여 동일한 키 사이에서는 알림의 순서가 보장되도록 한다.

# Link

BG-349