### PR TITLE
[BG-391]: reaction 채팅 생성 구현 (1.5h / 2.0h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/api/event/config/EventServiceConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/config/EventServiceConfig.kt
@@ -2,10 +2,14 @@ package com.backgu.amaker.api.event.config
 
 import com.backgu.amaker.application.event.service.EventAssignedUserService
 import com.backgu.amaker.application.event.service.EventService
+import com.backgu.amaker.application.event.service.ReactionEventService
+import com.backgu.amaker.application.event.service.ReactionOptionService
 import com.backgu.amaker.application.event.service.ReplyCommentService
 import com.backgu.amaker.application.event.service.ReplyEventService
 import com.backgu.amaker.infra.jpa.event.repository.EventAssignedUserRepository
 import com.backgu.amaker.infra.jpa.event.repository.EventRepository
+import com.backgu.amaker.infra.jpa.event.repository.ReactionEventRepository
+import com.backgu.amaker.infra.jpa.event.repository.ReactionOptionRepository
 import com.backgu.amaker.infra.jpa.event.repository.ReplyCommentRepository
 import com.backgu.amaker.infra.jpa.event.repository.ReplyEventRepository
 import org.springframework.context.annotation.Bean
@@ -26,4 +30,12 @@ class EventServiceConfig {
 
     @Bean
     fun eventService(eventRepository: EventRepository): EventService = EventService(eventRepository)
+
+    @Bean
+    fun reactionEventService(reactionEventRepository: ReactionEventRepository): ReactionEventService =
+        ReactionEventService(reactionEventRepository)
+
+    @Bean
+    fun reactionOptionService(reactionOptionRepository: ReactionOptionRepository): ReactionOptionService =
+        ReactionOptionService(reactionOptionRepository)
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventController.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.event.controller
 
+import com.backgu.amaker.api.event.dto.request.ReactionEventCreateRequest
 import com.backgu.amaker.api.event.dto.request.ReplyEventCreateRequest
 import com.backgu.amaker.api.event.dto.response.ReplyEventDetailResponse
 import com.backgu.amaker.api.event.service.EventFacadeService
@@ -23,6 +24,26 @@ class EventController(
     private val eventFacadeService: EventFacadeService,
     private val apiHandler: ApiHandler,
 ) : EventSwagger {
+    @GetMapping("/events/{event-id}/reply")
+    override fun getReplyEvent(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("chat-room-id") chatRoomId: Long,
+        @PathVariable("event-id") eventId: Long,
+    ): ResponseEntity<ApiResult<ReplyEventDetailResponse>> =
+        ResponseEntity
+            .ok()
+            .body(
+                apiHandler.onSuccess(
+                    ReplyEventDetailResponse.of(
+                        eventFacadeService.getReplyEvent(
+                            token.id,
+                            chatRoomId,
+                            eventId,
+                        ),
+                    ),
+                ),
+            )
+
     @PostMapping("/events/reply")
     override fun createReplyEvent(
         @AuthenticationPrincipal token: JwtAuthentication,
@@ -44,23 +65,24 @@ class EventController(
                     ).toUri(),
             ).build()
 
-    @GetMapping("/events/{event-id}/reply")
-    override fun getReplyEvent(
+    @PostMapping("/events/reaction")
+    override fun createReactionEvent(
         @AuthenticationPrincipal token: JwtAuthentication,
         @PathVariable("chat-room-id") chatRoomId: Long,
-        @PathVariable("event-id") eventId: Long,
-    ): ResponseEntity<ApiResult<ReplyEventDetailResponse>> =
+        @RequestBody @Valid request: ReactionEventCreateRequest,
+    ): ResponseEntity<Unit> =
         ResponseEntity
-            .ok()
-            .body(
-                apiHandler.onSuccess(
-                    ReplyEventDetailResponse.of(
-                        eventFacadeService.getReplyEvent(
-                            token.id,
-                            chatRoomId,
-                            eventId,
-                        ),
-                    ),
-                ),
-            )
+            .created(
+                ServletUriComponentsBuilder
+                    .fromCurrentContextPath()
+                    .path("/api/v1/events/{id}/reply")
+                    .buildAndExpand(
+                        eventFacadeService
+                            .createReactionEvent(
+                                token.id,
+                                chatRoomId,
+                                request.toDto(),
+                            ).id,
+                    ).toUri(),
+            ).build()
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventSwagger.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.event.controller
 
+import com.backgu.amaker.api.event.dto.request.ReactionEventCreateRequest
 import com.backgu.amaker.api.event.dto.request.ReplyEventCreateRequest
 import com.backgu.amaker.api.event.dto.response.ReplyEventDetailResponse
 import com.backgu.amaker.common.http.response.ApiResult
@@ -12,10 +13,26 @@ import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
 @Tag(name = "event", description = "이벤트 API")
 interface EventSwagger {
+    @Operation(summary = "reply 이벤트 상세조회", description = "reply 이벤트 상세조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "reply 이벤트 상세조회 성공",
+            ),
+        ],
+    )
+    fun getReplyEvent(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("chat-room-id") chatRoomId: Long,
+        @PathVariable("event-id") eventId: Long,
+    ): ResponseEntity<ApiResult<ReplyEventDetailResponse>>
+
     @Operation(summary = "reply 이벤트 생성", description = "reply 이벤트 생성합니다.")
     @ApiResponses(
         value = [
@@ -31,18 +48,19 @@ interface EventSwagger {
         @RequestBody @Valid request: ReplyEventCreateRequest,
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "reply 이벤트 상세조회", description = "reply 이벤트 상세조회합니다.")
+    @Operation(summary = "reaction 이벤트 생성", description = "reaction 이벤트 생성합니다.")
     @ApiResponses(
         value = [
             ApiResponse(
-                responseCode = "200",
-                description = "reply 이벤트 상세조회 성공",
+                responseCode = "201",
+                description = "reaction 이벤트 생성 성공",
             ),
         ],
     )
-    fun getReplyEvent(
-        @AuthenticationPrincipal token: JwtAuthentication,
-        @PathVariable("chat-room-id") chatRoomId: Long,
-        @PathVariable("event-id") eventId: Long,
-    ): ResponseEntity<ApiResult<ReplyEventDetailResponse>>
+    @PostMapping("/events/reaction")
+    fun createReactionEvent(
+        token: JwtAuthentication,
+        chatRoomId: Long,
+        request: ReactionEventCreateRequest,
+    ): ResponseEntity<Unit>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionEventCreateDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionEventCreateDto.kt
@@ -1,0 +1,13 @@
+package com.backgu.amaker.api.event.dto
+
+import java.time.LocalDateTime
+
+data class ReactionEventCreateDto(
+    val eventTitle: String,
+    val options: List<String>,
+    val assignees: List<String>,
+    val deadLine: LocalDateTime,
+    val notificationStartHour: Int,
+    val notificationStartMinute: Int,
+    val interval: Int,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionEventDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionEventDto.kt
@@ -1,0 +1,28 @@
+package com.backgu.amaker.api.event.dto
+
+import com.backgu.amaker.domain.event.ReactionEvent
+import com.backgu.amaker.domain.event.ReactionOption
+import java.time.LocalDateTime
+
+data class ReactionEventDto(
+    val id: Long,
+    val eventTitle: String,
+    val options: List<String>,
+    val deadLine: LocalDateTime,
+    val notificationStartTime: LocalDateTime,
+    val notificationInterval: Int,
+) {
+    companion object {
+        fun of(
+            reactionEvent: ReactionEvent,
+            options: List<ReactionOption>,
+        ) = ReactionEventDto(
+            id = reactionEvent.id,
+            eventTitle = reactionEvent.eventTitle,
+            options = options.map { it.content },
+            deadLine = reactionEvent.deadLine,
+            notificationStartTime = reactionEvent.notificationStartTime,
+            notificationInterval = reactionEvent.notificationInterval,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/request/ReactionEventCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/request/ReactionEventCreateRequest.kt
@@ -1,0 +1,39 @@
+package com.backgu.amaker.api.event.dto.request
+
+import com.backgu.amaker.api.event.dto.ReactionEventCreateDto
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
+
+data class ReactionEventCreateRequest(
+    @Schema(description = "제목", example = "제목 어때요?")
+    @field:NotBlank(message = "이벤트 제목을 입력해주세요.")
+    val eventTitle: String,
+    @Schema(description = "선택지", example = "[\"예\", \"아니오\"]")
+    val options: List<String>,
+    @Schema(description = "답변을 요청할 인원", example = "[\"user1\", \"user2\"]")
+    @field:Size(min = 1, message = "최소 한 명 이상의 인원을 지정해야 합니다.")
+    val assignees: List<String>,
+    @Schema(description = "마감 기한", example = "2021-08-01T00:00:00")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val deadLine: LocalDateTime,
+    @Schema(description = "알림 시작 시간", example = "1")
+    val notificationStartHour: Int,
+    @Schema(description = "알림 시작 분", example = "30")
+    val notificationStartMinute: Int,
+    @Schema(description = "알림 주기", example = "15")
+    val interval: Int,
+) {
+    fun toDto() =
+        ReactionEventCreateDto(
+            eventTitle = eventTitle,
+            options = options,
+            assignees = assignees,
+            deadLine = deadLine,
+            notificationStartMinute = notificationStartMinute,
+            notificationStartHour = notificationStartHour,
+            interval = interval,
+        )
+}

--- a/api/src/test/kotlin/com/backgu/amaker/api/event/service/EventFacadeServiceTest.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/event/service/EventFacadeServiceTest.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.api.event.service
 
 import com.backgu.amaker.api.common.container.IntegrationTest
+import com.backgu.amaker.api.event.dto.ReactionEventCreateDto
 import com.backgu.amaker.api.event.dto.ReplyEventCreateDto
 import com.backgu.amaker.api.fixture.EventFixtureFacade
 import com.backgu.amaker.domain.chat.ChatRoom
@@ -38,7 +39,6 @@ class EventFacadeServiceTest : IntegrationTest() {
     @DisplayName("reply 이벤트 생성 테스트")
     fun createReplyEvent() {
         // given
-
         val replyEventCreateDto =
             ReplyEventCreateDto(
                 eventTitle = "eventTitle",
@@ -61,6 +61,34 @@ class EventFacadeServiceTest : IntegrationTest() {
         // then
         assertThat(replyEvent).isNotNull()
         assertThat(replyEvent.deadLine).isEqualTo(replyEventCreateDto.deadLine)
+    }
+
+    @Test
+    @DisplayName("reaction 이벤트 생성 테스트")
+    fun createReactionEvent() {
+        // given
+        val reactionEventCreateDto =
+            ReactionEventCreateDto(
+                eventTitle = "eventTitle",
+                deadLine = LocalDateTime.now().plusDays(1),
+                notificationStartHour = 1,
+                notificationStartMinute = 30,
+                interval = 10,
+                options = listOf("option1", "option2"),
+                assignees = listOf("$DEFAULT_USER_ID@email.com"),
+            )
+
+        // when
+        val replyEvent =
+            eventFacadeService.createReactionEvent(
+                userId = DEFAULT_USER_ID,
+                chatRoomId = chatRoom.id,
+                reactionEventCreateDto = reactionEventCreateDto,
+            )
+
+        // then
+        assertThat(replyEvent).isNotNull()
+        assertThat(replyEvent.deadLine).isEqualTo(reactionEventCreateDto.deadLine)
     }
 
     @Test

--- a/docker-compose-kafka.yaml
+++ b/docker-compose-kafka.yaml
@@ -5,8 +5,6 @@ services:
     ports:
       - "9092:9092"
       - "9093:9093"
-    networks:
-      - backgu_dev_net
     environment:
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_NODE_ID: 1
@@ -24,6 +22,3 @@ services:
     volumes:
       - ./kafka_data:/var/lib/kafka/data
 
-networks:
-  backgu_dev_net:
-    external: true

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/chat/Chat.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/chat/Chat.kt
@@ -1,5 +1,7 @@
 package com.backgu.amaker.domain.chat
 
+import com.backgu.amaker.domain.event.Event
+import com.backgu.amaker.domain.event.ReactionEvent
 import com.backgu.amaker.domain.event.ReplyEvent
 import com.backgu.amaker.domain.user.User
 import java.time.LocalDateTime
@@ -31,6 +33,22 @@ class Chat(
         eventDetails = eventDetails,
     )
 
+    fun createReactionEvent(
+        deadLine: LocalDateTime,
+        notificationStartHour: Int,
+        notificationStartMinute: Int,
+        notificationInterval: Int,
+    ) = ReactionEvent(
+        id = id,
+        eventTitle = content,
+        deadLine = deadLine,
+        notificationStartTime =
+            deadLine
+                .minusHours(notificationStartHour.toLong())
+                .minusMinutes(notificationStartMinute.toLong()),
+        notificationInterval = notificationInterval,
+    )
+
     fun createDefaultChatWithUser(user: User) =
         DefaultChatWithUser(
             id = id,
@@ -43,7 +61,7 @@ class Chat(
         )
 
     fun createEventChatWithUser(
-        event: ReplyEvent,
+        event: Event,
         user: User,
         assignedUsers: List<User>,
     ) = EventChatWithUser(

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionEvent.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionEvent.kt
@@ -1,0 +1,21 @@
+package com.backgu.amaker.domain.event
+
+import java.time.LocalDateTime
+
+class ReactionEvent(
+    id: Long,
+    eventTitle: String,
+    deadLine: LocalDateTime,
+    notificationStartTime: LocalDateTime,
+    notificationInterval: Int,
+    createdAt: LocalDateTime = LocalDateTime.now(),
+    updatedAt: LocalDateTime = LocalDateTime.now(),
+) : Event(id, eventTitle, deadLine, notificationStartTime, notificationInterval, createdAt, updatedAt) {
+    fun createReactionOption(contents: List<String>) =
+        contents.map {
+            ReactionOption(
+                eventId = id,
+                content = it,
+            )
+        }
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionOption.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionOption.kt
@@ -1,0 +1,11 @@
+package com.backgu.amaker.domain.event
+
+import java.time.LocalDateTime
+
+class ReactionOption(
+    val id: Long = 0L,
+    val eventId: Long,
+    val content: String,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/domain/src/test/kotlin/com/backgu/amaker/domain/chat/ChatTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/domain/chat/ChatTest.kt
@@ -24,7 +24,6 @@ class ChatTest {
         val notificationStartMinute = 30
 
         // when
-
         val replyEvent =
             chat.createReplyEvent(
                 deadLine = deadLine,
@@ -32,6 +31,39 @@ class ChatTest {
                 notificationStartMinute = notificationStartMinute,
                 notificationInterval = 10,
                 eventDetails = "이벤트 상세 내용",
+            )
+
+        // then
+        assertThat(replyEvent.eventTitle).isEqualTo(chat.content)
+        assertThat(replyEvent.deadLine).isEqualTo(deadLine)
+        assertThat(replyEvent.notificationStartTime).isEqualTo(
+            deadLine.minusHours(notificationStartHour.toLong()).minusMinutes(notificationStartMinute.toLong()),
+        )
+    }
+
+    @Test
+    @DisplayName("reaction 이벤트 생성 테스트")
+    fun creatReactionEvent() {
+        // given
+        val chat =
+            Chat(
+                id = 1,
+                userId = "user1",
+                chatRoomId = 1,
+                content = "안녕하세요",
+                chatType = ChatType.GENERAL,
+            )
+        val deadLine = LocalDateTime.now().plusDays(1)
+        val notificationStartHour = 1
+        val notificationStartMinute = 30
+
+        // when
+        val replyEvent =
+            chat.createReactionEvent(
+                deadLine = deadLine,
+                notificationStartHour = notificationStartHour,
+                notificationStartMinute = notificationStartMinute,
+                notificationInterval = 10,
             )
 
         // then

--- a/domain/src/test/kotlin/com/backgu/amaker/domain/event/ReactionTest.kt
+++ b/domain/src/test/kotlin/com/backgu/amaker/domain/event/ReactionTest.kt
@@ -1,0 +1,33 @@
+package com.backgu.amaker.domain.event
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import java.time.LocalDateTime
+import kotlin.test.Test
+
+@DisplayName("Reation 테스트")
+class ReactionTest {
+    @Test
+    @DisplayName("reaction option 생성 테스트")
+    fun createReactionOption() {
+        // given
+        val reactionEvent =
+            ReactionEvent(
+                id = 1,
+                eventTitle = "eventTitle",
+                deadLine = LocalDateTime.now().plusDays(1),
+                notificationStartTime = LocalDateTime.now().plusDays(1),
+                notificationInterval = 10,
+            )
+        val contents = listOf("content1", "content2")
+
+        // when
+        val reactionOptions = reactionEvent.createReactionOption(contents)
+
+        // then
+        reactionOptions.forEachIndexed { index, reactionOption ->
+            assertThat(reactionOption.eventId).isEqualTo(reactionEvent.id)
+            assertThat(reactionOption.content).isEqualTo(contents[index])
+        }
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionEventService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionEventService.kt
@@ -1,0 +1,16 @@
+package com.backgu.amaker.application.event.service
+
+import com.backgu.amaker.domain.event.ReactionEvent
+import com.backgu.amaker.infra.jpa.event.entity.ReactionEventEntity
+import com.backgu.amaker.infra.jpa.event.repository.ReactionEventRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReactionEventService(
+    private val reactionEventRepository: ReactionEventRepository,
+) {
+    @Transactional
+    fun save(reactionEvent: ReactionEvent): ReactionEvent = reactionEventRepository.save(ReactionEventEntity.of(reactionEvent)).toDomain()
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionOptionService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionOptionService.kt
@@ -1,0 +1,19 @@
+package com.backgu.amaker.application.event.service
+
+import com.backgu.amaker.domain.event.ReactionOption
+import com.backgu.amaker.infra.jpa.event.entity.ReactionOptionEntity
+import com.backgu.amaker.infra.jpa.event.repository.ReactionOptionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReactionOptionService(
+    private val reactionOptionRepository: ReactionOptionRepository,
+) {
+    @Transactional
+    fun saveAll(options: List<ReactionOption>): List<ReactionOption> =
+        reactionOptionRepository
+            .saveAll(options.map { ReactionOptionEntity.of(it) })
+            .map { it.toDomain() }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/entity/ReactionEventEntity.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/entity/ReactionEventEntity.kt
@@ -1,0 +1,46 @@
+package com.backgu.amaker.infra.jpa.event.entity
+
+import com.backgu.amaker.domain.event.ReactionEvent
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ReactionEvent")
+@Table(name = "reaction_event")
+@DiscriminatorValue(value = "REACTION")
+class ReactionEventEntity(
+    id: Long,
+    eventTitle: String,
+    deadLine: LocalDateTime,
+    notificationStartTime: LocalDateTime,
+    notificationInterval: Int,
+) : EventEntity(
+        id = id,
+        eventTitle = eventTitle,
+        deadLine = deadLine,
+        notificationStartTime = notificationStartTime,
+        notificationInterval = notificationInterval,
+    ) {
+    override fun toDomain(): ReactionEvent =
+        ReactionEvent(
+            id = id,
+            eventTitle = eventTitle,
+            deadLine = deadLine,
+            notificationStartTime = notificationStartTime,
+            notificationInterval = notificationInterval,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    companion object {
+        fun of(reactionEvent: ReactionEvent) =
+            ReactionEventEntity(
+                id = reactionEvent.id,
+                eventTitle = reactionEvent.eventTitle,
+                deadLine = reactionEvent.deadLine,
+                notificationStartTime = reactionEvent.notificationStartTime,
+                notificationInterval = reactionEvent.notificationInterval,
+            )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/entity/ReactionOptionEntity.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/entity/ReactionOptionEntity.kt
@@ -1,0 +1,27 @@
+package com.backgu.amaker.infra.jpa.event.entity
+
+import com.backgu.amaker.domain.event.ReactionOption
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "ReactionOption")
+@Table(name = "reaction_option")
+class ReactionOptionEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    val eventId: Long,
+    val content: String,
+) {
+    fun toDomain(): ReactionOption = ReactionOption(id = id, eventId = eventId, content = content)
+
+    companion object {
+        fun of(reactionOption: ReactionOption): ReactionOptionEntity =
+            ReactionOptionEntity(eventId = reactionOption.eventId, content = reactionOption.content)
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionEventRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionEventRepository.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.infra.jpa.event.repository
+
+import com.backgu.amaker.infra.jpa.event.entity.ReactionEventEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReactionEventRepository : JpaRepository<ReactionEventEntity, Long>

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionOptionRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionOptionRepository.kt
@@ -1,0 +1,6 @@
+package com.backgu.amaker.infra.jpa.event.repository
+
+import com.backgu.amaker.infra.jpa.event.entity.ReactionOptionEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReactionOptionRepository : JpaRepository<ReactionOptionEntity, Long>


### PR DESCRIPTION
# Why
reply 이벤트 생성과 로직이 유사해서 빨리 끝났다

# How
현재 `Reaction Entity`는 단지 `Event`의 아이디만 가지고 있는 구조이다
`option`에 `event`의 id를 바로 사용하는 것이 부자연스럽다고 생각해서
이렇게 했는데 고민해 봐야 될듯

# Link

BG-391