### PR TITLE
[BG-244]: 리엑션 이벤트에 대한 응답 등록 API를 개발한다 (2h / 3h)

### DIFF
--- a/api/src/main/kotlin/com/backgu/amaker/api/event/config/EventServiceConfig.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/config/EventServiceConfig.kt
@@ -2,12 +2,14 @@ package com.backgu.amaker.api.event.config
 
 import com.backgu.amaker.application.event.service.EventAssignedUserService
 import com.backgu.amaker.application.event.service.EventService
+import com.backgu.amaker.application.event.service.ReactionCommentService
 import com.backgu.amaker.application.event.service.ReactionEventService
 import com.backgu.amaker.application.event.service.ReactionOptionService
 import com.backgu.amaker.application.event.service.ReplyCommentService
 import com.backgu.amaker.application.event.service.ReplyEventService
 import com.backgu.amaker.infra.jpa.event.repository.EventAssignedUserRepository
 import com.backgu.amaker.infra.jpa.event.repository.EventRepository
+import com.backgu.amaker.infra.jpa.event.repository.ReactionCommentRepository
 import com.backgu.amaker.infra.jpa.event.repository.ReactionEventRepository
 import com.backgu.amaker.infra.jpa.event.repository.ReactionOptionRepository
 import com.backgu.amaker.infra.jpa.event.repository.ReplyCommentRepository
@@ -38,4 +40,8 @@ class EventServiceConfig {
     @Bean
     fun reactionOptionService(reactionOptionRepository: ReactionOptionRepository): ReactionOptionService =
         ReactionOptionService(reactionOptionRepository)
+
+    @Bean
+    fun reactionCommentService(reactionCommentRepository: ReactionCommentRepository): ReactionCommentService =
+        ReactionCommentService(reactionCommentRepository)
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentController.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentController.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.api.event.controller
 
 import com.backgu.amaker.api.event.dto.query.ReplyQueryRequest
+import com.backgu.amaker.api.event.dto.request.ReactionCommentCreateRequest
 import com.backgu.amaker.api.event.dto.request.ReplyCommentCreateRequest
 import com.backgu.amaker.api.event.dto.response.ReplyCommentWithUserResponse
 import com.backgu.amaker.api.event.dto.response.ReplyCommentsViewResponse
@@ -29,16 +30,6 @@ class EventCommentController(
     private val eventCommentFacadeService: EventCommentFacadeService,
     private val apiHandler: ApiHandler,
 ) : EventCommentSwagger {
-    @PostMapping("/events/{event-id}/reply/comments")
-    override fun createReplyComment(
-        @AuthenticationPrincipal token: JwtAuthentication,
-        @PathVariable("event-id") eventId: Long,
-        @RequestBody @Valid replyCommentCreateRequest: ReplyCommentCreateRequest,
-    ): ResponseEntity<Unit> {
-        eventCommentFacadeService.createReplyComment(token.id, eventId, replyCommentCreateRequest.toDto())
-        return ResponseEntity.status(HttpStatus.CREATED).build()
-    }
-
     @GetMapping("/events/{event-id}/reply/comments")
     override fun findReplyComments(
         @AuthenticationPrincipal token: JwtAuthentication,
@@ -62,5 +53,25 @@ class EventCommentController(
                 ),
             ),
         )
+    }
+
+    @PostMapping("/events/{event-id}/reply/comments")
+    override fun createReplyComment(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("event-id") eventId: Long,
+        @RequestBody @Valid replyCommentCreateRequest: ReplyCommentCreateRequest,
+    ): ResponseEntity<Unit> {
+        eventCommentFacadeService.createReplyComment(token.id, eventId, replyCommentCreateRequest.toDto())
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @PostMapping("/events/{event-id}/reaction/comments")
+    override fun createReactionComment(
+        @AuthenticationPrincipal token: JwtAuthentication,
+        @PathVariable("event-id") eventId: Long,
+        @RequestBody @Valid reactionCommentCreateRequest: ReactionCommentCreateRequest,
+    ): ResponseEntity<Unit> {
+        eventCommentFacadeService.createReactionComment(token.id, eventId, reactionCommentCreateRequest.toDto())
+        return ResponseEntity.status(HttpStatus.CREATED).build()
     }
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentSwagger.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/controller/EventCommentSwagger.kt
@@ -1,6 +1,7 @@
 package com.backgu.amaker.api.event.controller
 
 import com.backgu.amaker.api.event.dto.query.ReplyQueryRequest
+import com.backgu.amaker.api.event.dto.request.ReactionCommentCreateRequest
 import com.backgu.amaker.api.event.dto.request.ReplyCommentCreateRequest
 import com.backgu.amaker.api.event.dto.response.ReplyCommentWithUserResponse
 import com.backgu.amaker.common.http.response.ApiResult
@@ -14,6 +15,21 @@ import org.springframework.http.ResponseEntity
 
 @Tag(name = "eventComment", description = "이벤트 응답 API")
 interface EventCommentSwagger {
+    @Operation(summary = "reply 이벤트 응답 조회", description = "reply 이벤트 응답 조회합니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "reply 이벤트 응답 조회 성공",
+            ),
+        ],
+    )
+    fun findReplyComments(
+        token: JwtAuthentication,
+        eventId: Long,
+        replyQueryRequest: ReplyQueryRequest,
+    ): ResponseEntity<ApiResult<PageResponse<ReplyCommentWithUserResponse>>>
+
     @Operation(summary = "reply 이벤트 응답 생성", description = "reply 이벤트 응답 생성합니다.")
     @ApiResponses(
         value = [
@@ -29,18 +45,18 @@ interface EventCommentSwagger {
         replyCommentCreateRequest: ReplyCommentCreateRequest,
     ): ResponseEntity<Unit>
 
-    @Operation(summary = "reply 이벤트 응답 조회", description = "reply 이벤트 응답 조회합니다.")
+    @Operation(summary = "reaction 이벤트 응답 생성", description = "reaction 이벤트 응답 생성합니다.")
     @ApiResponses(
         value = [
             ApiResponse(
-                responseCode = "200",
-                description = "reply 이벤트 응답 조회 성공",
+                responseCode = "201",
+                description = "reaction 이벤트 응답 생성 성공",
             ),
         ],
     )
-    fun findReplyComments(
+    fun createReactionComment(
         token: JwtAuthentication,
         eventId: Long,
-        replyQueryRequest: ReplyQueryRequest,
-    ): ResponseEntity<ApiResult<PageResponse<ReplyCommentWithUserResponse>>>
+        reactionCommentCreateRequest: ReactionCommentCreateRequest,
+    ): ResponseEntity<Unit>
 }

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionCommentCreateDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionCommentCreateDto.kt
@@ -1,0 +1,5 @@
+package com.backgu.amaker.api.event.dto
+
+data class ReactionCommentCreateDto(
+    val optionId: Long,
+)

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionCommentDto.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/ReactionCommentDto.kt
@@ -1,0 +1,25 @@
+package com.backgu.amaker.api.event.dto
+
+import com.backgu.amaker.domain.event.ReactionComment
+import java.time.LocalDateTime
+
+data class ReactionCommentDto(
+    val id: Long,
+    val userId: String,
+    val eventId: Long,
+    val optionId: Long,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    companion object {
+        fun of(reactionComment: ReactionComment) =
+            ReactionCommentDto(
+                id = reactionComment.id,
+                userId = reactionComment.userId,
+                eventId = reactionComment.eventId,
+                optionId = reactionComment.optionId,
+                createdAt = reactionComment.createdAt,
+                updatedAt = reactionComment.updatedAt,
+            )
+    }
+}

--- a/api/src/main/kotlin/com/backgu/amaker/api/event/dto/request/ReactionCommentCreateRequest.kt
+++ b/api/src/main/kotlin/com/backgu/amaker/api/event/dto/request/ReactionCommentCreateRequest.kt
@@ -1,0 +1,14 @@
+package com.backgu.amaker.api.event.dto.request
+
+import com.backgu.amaker.api.event.dto.ReactionCommentCreateDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class ReactionCommentCreateRequest(
+    @Schema(description = "option id", example = "1")
+    val optionId: Long,
+) {
+    fun toDto() =
+        ReactionCommentCreateDto(
+            optionId = optionId,
+        )
+}

--- a/api/src/test/kotlin/com/backgu/amaker/api/fixture/ChatRoomFacadeFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/fixture/ChatRoomFacadeFixture.kt
@@ -1,5 +1,6 @@
 package com.backgu.amaker.api.fixture
 
+import com.backgu.amaker.api.fixture.dto.ChatRoomFixtureDto
 import com.backgu.amaker.domain.user.User
 import com.backgu.amaker.domain.workspace.Workspace
 import com.backgu.amaker.domain.workspace.WorkspaceUser

--- a/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReactionCommentFixture.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReactionCommentFixture.kt
@@ -1,0 +1,25 @@
+package com.backgu.amaker.api.fixture
+
+import com.backgu.amaker.domain.event.ReactionComment
+import com.backgu.amaker.infra.jpa.event.entity.ReactionCommentEntity
+import com.backgu.amaker.infra.jpa.event.repository.ReactionCommentRepository
+import org.springframework.stereotype.Component
+
+@Component
+class ReactionCommentFixture(
+    val reactionCommentRepository: ReactionCommentRepository,
+) {
+    fun createPersistedReactionComment(
+        userId: String,
+        eventId: Long,
+        optionId: Long,
+    ): ReactionComment =
+        reactionCommentRepository
+            .save(
+                ReactionCommentEntity(
+                    userId = userId,
+                    eventId = eventId,
+                    optionId = optionId,
+                ),
+            ).toDomain()
+}

--- a/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReactionCommentFixtureFacade.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/fixture/ReactionCommentFixtureFacade.kt
@@ -1,0 +1,35 @@
+package com.backgu.amaker.api.fixture
+
+import com.backgu.amaker.api.fixture.dto.ReactionCommentFixtureDto
+import com.backgu.amaker.domain.chat.ChatRoomType
+import com.backgu.amaker.domain.chat.ChatType
+import org.springframework.stereotype.Component
+
+@Component
+class ReactionCommentFixtureFacade(
+    val reactionCommentFixture: ReactionCommentFixture,
+    val reactionEventFixture: ReactionEventFixture,
+    val reactionOptionFixture: ReactionOptionFixture,
+    val chatRoomFixture: ChatRoomFixture,
+    val chatFixture: ChatFixture,
+    val eventAssignedUserFixture: EventAssignedUserFixture,
+    val userFixture: UserFixture,
+    private val workspaceFixture: WorkspaceFixture,
+    private val workspaceUserFixture: WorkspaceUserFixture,
+) {
+    fun setUp(
+        userId: String = "test-user-id",
+        name: String = "김리더",
+        workspaceId: Long = 1L,
+    ): ReactionCommentFixtureDto {
+        val workspace = workspaceFixture.createPersistedWorkspace(workspaceId, "test-workspace")
+        workspaceUserFixture.createPersistedWorkspaceUser(workspace.id, userId)
+        userFixture.createPersistedUser(id = userId, name = name)
+        val chatRoom = chatRoomFixture.createPersistedChatRoom(workspace.id, ChatRoomType.DEFAULT)
+        val chat = chatFixture.createPersistedChat(chatRoom.id, userId, chatType = ChatType.REPLY)
+        val reactionEvent = reactionEventFixture.createPersistedReactionEvent(chat.id)
+        val options = reactionOptionFixture.createPersistedReactionOptions(reactionEvent.id)
+        eventAssignedUserFixture.createPersistedEventAssignedUser(userId, reactionEvent.id)
+        return ReactionCommentFixtureDto(reactionEvent, options)
+    }
+}

--- a/api/src/test/kotlin/com/backgu/amaker/api/fixture/dto/ChatRoomFixtureDto.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/fixture/dto/ChatRoomFixtureDto.kt
@@ -1,4 +1,4 @@
-package com.backgu.amaker.api.fixture
+package com.backgu.amaker.api.fixture.dto
 
 import com.backgu.amaker.domain.chat.ChatRoom
 import com.backgu.amaker.domain.user.User

--- a/api/src/test/kotlin/com/backgu/amaker/api/fixture/dto/ReactionCommentFixtureDto.kt
+++ b/api/src/test/kotlin/com/backgu/amaker/api/fixture/dto/ReactionCommentFixtureDto.kt
@@ -1,0 +1,9 @@
+package com.backgu.amaker.api.fixture.dto
+
+import com.backgu.amaker.domain.event.ReactionEvent
+import com.backgu.amaker.domain.event.ReactionOption
+
+data class ReactionCommentFixtureDto(
+    val reactionEvent: ReactionEvent,
+    val options: List<ReactionOption>,
+)

--- a/common/src/main/kotlin/com/backgu/amaker/common/status/StatusCode.kt
+++ b/common/src/main/kotlin/com/backgu/amaker/common/status/StatusCode.kt
@@ -59,6 +59,9 @@ enum class StatusCode(
     // realtime
     REALTIME_NOT_FOUND("4000", "세션정보를 찾을 수 없습니다."),
 
+    // reactionOption
+    REACTION_OPTION_NOT_FOUND("4000", "이벤트 옵션을 찾을 수 없습니다."),
+
     // serverError
     SERVER_ERROR("5000", "서버 에러입니다."),
 }

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionComment.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionComment.kt
@@ -1,0 +1,16 @@
+package com.backgu.amaker.domain.event
+
+import java.time.LocalDateTime
+
+class ReactionComment(
+    val id: Long = 0L,
+    val userId: String,
+    val eventId: Long,
+    var optionId: Long,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun toggleOptionId(optionId: Long) {
+        this.optionId = optionId
+    }
+}

--- a/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionEvent.kt
+++ b/domain/src/main/kotlin/com/backgu/amaker/domain/event/ReactionEvent.kt
@@ -18,4 +18,13 @@ class ReactionEvent(
                 content = it,
             )
         }
+
+    fun createReactionComment(
+        userId: String,
+        optionId: Long,
+    ) = ReactionComment(
+        eventId = id,
+        userId = userId,
+        optionId = optionId,
+    )
 }

--- a/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionCommentService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionCommentService.kt
@@ -1,0 +1,24 @@
+package com.backgu.amaker.application.event.service
+
+import com.backgu.amaker.domain.event.ReactionComment
+import com.backgu.amaker.domain.event.ReactionEvent
+import com.backgu.amaker.domain.user.User
+import com.backgu.amaker.infra.jpa.event.entity.ReactionCommentEntity
+import com.backgu.amaker.infra.jpa.event.repository.ReactionCommentRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReactionCommentService(
+    private val reactionCommentRepository: ReactionCommentRepository,
+) {
+    @Transactional
+    fun save(reactionComment: ReactionComment): ReactionComment =
+        reactionCommentRepository.save(ReactionCommentEntity.of(reactionComment)).toDomain()
+
+    fun findByEventIdAndUserId(
+        event: ReactionEvent,
+        user: User,
+    ): ReactionComment? = reactionCommentRepository.findByEventIdAndUserId(event.id, user.id)?.toDomain()
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionOptionService.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/application/event/service/ReactionOptionService.kt
@@ -1,5 +1,7 @@
 package com.backgu.amaker.application.event.service
 
+import com.backgu.amaker.common.exception.BusinessException
+import com.backgu.amaker.common.status.StatusCode
 import com.backgu.amaker.domain.event.ReactionOption
 import com.backgu.amaker.infra.jpa.event.entity.ReactionOptionEntity
 import com.backgu.amaker.infra.jpa.event.repository.ReactionOptionRepository
@@ -18,4 +20,12 @@ class ReactionOptionService(
             .map { it.toDomain() }
 
     fun getAllByEventId(eventId: Long): List<ReactionOption> = reactionOptionRepository.findAllByEventId(eventId).map { it.toDomain() }
+
+    fun validateOptionInEvent(
+        optionId: Long,
+        eventId: Long,
+    ) {
+        reactionOptionRepository.findByIdAndEventId(optionId, eventId)
+            ?: throw BusinessException(StatusCode.REACTION_OPTION_NOT_FOUND)
+    }
 }

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/entity/ReactionCommentEntity.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/entity/ReactionCommentEntity.kt
@@ -1,0 +1,44 @@
+package com.backgu.amaker.infra.jpa.event.entity
+
+import com.backgu.amaker.domain.event.ReactionComment
+import com.backgu.amaker.infra.jpa.common.entity.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "ReactionComment")
+@Table(name = "reaction_comment")
+class ReactionCommentEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Column(nullable = false)
+    val userId: String,
+    @Column(nullable = false)
+    val eventId: Long,
+    @Column(nullable = false)
+    var optionId: Long,
+) : BaseTimeEntity() {
+    fun toDomain(): ReactionComment =
+        ReactionComment(
+            id = id,
+            userId = userId,
+            eventId = eventId,
+            optionId = optionId,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    companion object {
+        fun of(reactionComment: ReactionComment): ReactionCommentEntity =
+            ReactionCommentEntity(
+                id = reactionComment.id,
+                userId = reactionComment.userId,
+                eventId = reactionComment.eventId,
+                optionId = reactionComment.optionId,
+            )
+    }
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionCommentRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionCommentRepository.kt
@@ -1,0 +1,11 @@
+package com.backgu.amaker.infra.jpa.event.repository
+
+import com.backgu.amaker.infra.jpa.event.entity.ReactionCommentEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReactionCommentRepository : JpaRepository<ReactionCommentEntity, Long> {
+    fun findByEventIdAndUserId(
+        eventId: Long,
+        userId: String,
+    ): ReactionCommentEntity?
+}

--- a/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionOptionRepository.kt
+++ b/infra/src/main/kotlin/com/backgu/amaker/infra/jpa/event/repository/ReactionOptionRepository.kt
@@ -5,4 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ReactionOptionRepository : JpaRepository<ReactionOptionEntity, Long> {
     fun findAllByEventId(eventId: Long): List<ReactionOptionEntity>
+
+    fun findByIdAndEventId(
+        optionId: Long,
+        eventId: Long,
+    ): ReactionOptionEntity?
 }


### PR DESCRIPTION
# Why
reply comment 생성 로직과 유사하여 빨리 끝났다

# How
등록된 comment가 있으면 변경하고
없으면 생성하게 만들었다

변경하는 부분을 patch로 따로 빼야 될지 생각해 봐야 할듯..

# Link

BG-244